### PR TITLE
Update email address in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ A:  No, anyone can file an advisory against any package. The legitimacy of
 A: Yes, instead of creating a full advisory yourself you can also
    [open an issue on the security-advisories repo](https://github.com/haskell/security-advisories/issues)
    or email information about the vulnerability to
-   [TODO@example.com](mailto:TODO@example.com).
+   [security-advisories@haskell.org](mailto:security-advisories@haskell.org).
 
 **Q: Does this project have a GPG key or other means of handling embargoed vulnerabilities?**
 


### PR DESCRIPTION
It now matches our mailing list


---

## Advisory

- [ ] It's not duplicated
- [ ] All fields are filled
- [ ] It complies to `hsec-tools`

## hsec-tools

- [ ] If dependencies change: caba freeze is up-to-date
- [ ] Previous advisories are still valid

