### PR TITLE
Minor nitpicks in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,10 +5,10 @@
 
 - [ ] It's not duplicated
 - [ ] All fields are filled
-- [ ] It complies to `hsec-tools`
+- [ ] It is validated by `hsec-tools`
 
 ## hsec-tools
 
-- [ ] If dependencies change: caba freeze is up-to-date
+- [ ] If dependencies change: `cabal freeze` is up to date
 - [ ] Previous advisories are still valid
 


### PR DESCRIPTION
This adds a bit of Markdown formatting, fixes a typo, and removes the hyphens in "up to date" (see e.g. https://writingexplained.org/up-to-date-hyphenated for the rule)

