### PR TITLE
Remove cabal freeze leftover mentions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,4 @@
 
 ## hsec-tools
 
-- [ ] If dependencies change: `cabal freeze` is up to date
 - [ ] Previous advisories are still valid
-

--- a/code/hsec-tools/README.md
+++ b/code/hsec-tools/README.md
@@ -5,11 +5,3 @@
 ## Building
 
 We aim to support both regular cabal-based and nix-based builds.
-
-## Developping
-
-Whenever you add or change denpendencies, update cabal freeze file:
-
-```
-cabal freeze
-```


### PR DESCRIPTION
Since the file has been removed, we can remove the related instructions.