### PR TITLE
tools: parse "arch" field

### DIFF
--- a/code/hsec-tools/src/Security/Advisories.hs
+++ b/code/hsec-tools/src/Security/Advisories.hs
@@ -228,7 +228,7 @@ parseAdvisoryTable table = runTableParser $ do
           optional tbl "os" $
             isArrayOf (isString >=> operatingSystem)
         arch <-
-          optional tbl "os" $
+          optional tbl "arch" $
             isArrayOf (isString >=> architecture)
         decls <-
           maybe [] Map.toList


### PR DESCRIPTION
Fix `arch` value being read from `os` field (probably a copy/paste error).
