### PR TITLE
HSEC-2023-0001: aeson hash flooding

### DIFF
--- a/advisories/hackage/aeson/HSEC-2023-0001.md
+++ b/advisories/hackage/aeson/HSEC-2023-0001.md
@@ -1,0 +1,24 @@
+```toml
+[advisory]
+id = "HSEC-2023-0001"
+package = "aeson"
+date = 2021-09-11
+url = "https://cs-syd.eu/posts/2021-09-11-json-vulnerability"
+cwe = [328, 400]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
+keywords = ["json", "dos"]
+aliases = ["CVE-2022-3433"]
+
+[[versions]]
+introduced = "0.4.0.0"
+fixed = "2.0.1.0"
+```
+
+# Hash flooding vulnerability in aeson
+
+*aeson* was vulnerable to hash flooding (a.k.a. hash DoS).  The
+issue is a consequence of the HashMap implementation from
+*unordered-containers*.  It results in a denial of service through
+CPU consumption.  This technique has been used in real-world attacks
+against a variety of languages, libraries and frameworks over the
+years.


### PR DESCRIPTION
Add aeson hash flooding advisory.

This should put our CI through its paces.  Some other things to note/discuss:

- [ ] Are we happy with the topology: `advisories/hackage/<package-name>`?
- [x] If so, we need to add a uniqueness check for the `HSEC` identifier, because they'll be spread across different directories. (#38)
- [x] Are we happy with naming the advisory files after the `HSEC` identifier?  If so, we should (eventually) extend the checks to make sure that the ID in the TOML header matches the filename.  (https://github.com/haskell/security-advisories/issues/40)

Later, we could add merge automation to select the next appropriate `HSEC` identifier and update the commit before merging.  It's a "nice to have" and we can do it later.