### PR TITLE
ci: check HSEC id uniqueness

### DIFF
--- a/.github/workflows/check-advisories.yml
+++ b/.github/workflows/check-advisories.yml
@@ -19,7 +19,7 @@ jobs:
           name: ${{ inputs.artifact-name }}
           path: ~/.local/bin
       - run: chmod +x ~/.local/bin/hsec-tools
-      - name: Run advisories checks
+      - name: Run advisory syntax checks
         run: |
           cd source
           RESULT=0
@@ -30,3 +30,7 @@ jobs:
             hsec-tools check < "$FILE" || RESULT=1
           done < <(find advisories EXAMPLE_README.md EXAMPLE_ADVISORY.md -type f -name "*.md")
           exit $RESULT
+      - name: Run advisory uniqueness checks
+        run: |
+          ! find source/advisories -name '*.md' -print0 \
+            | xargs -0n1 basename | sort | uniq -c | grep -E -v '[[:space:]]*1 '


### PR DESCRIPTION
Add a CI check that HSEC ids (or the filenames, at least) are unique.

I pushed a branch with a conflict to test the new CI step.  Result:
https://github.com/frasertweedale/security-advisories/actions/runs/5251623664/jobs/9486797411