### PR TITLE
tools: check filename matches advisory ID

### DIFF
--- a/.github/workflows/check-advisories.yml
+++ b/.github/workflows/check-advisories.yml
@@ -27,7 +27,7 @@ jobs:
           (echo '```toml'; sed -e '1,/```toml/d' README.md) > EXAMPLE_README.md
           while read FILE ; do
             echo -n "$FILE: "
-            hsec-tools check < "$FILE" || RESULT=1
+            hsec-tools check "$FILE" || RESULT=1
           done < <(find advisories EXAMPLE_README.md EXAMPLE_ADVISORY.md -type f -name "*.md")
           exit $RESULT
       - name: Run advisory uniqueness checks

--- a/code/hsec-tools/app/Main.hs
+++ b/code/hsec-tools/app/Main.hs
@@ -20,20 +20,28 @@ cliOpts = info (commandsParser <**> helper) (fullDesc <> header "Haskell Advisor
       subparser
         (  command "check" (info commandCheck mempty)
         <> command "render" (info commandRender mempty)
-        <> command "help" (info (pure displayHelp) mempty)
+        <> command "help" (info commandHelp mempty)
         )
-    displayHelp :: IO ()
-    displayHelp = void $ handleParseResult $ execParserPure defaultPrefs cliOpts ["-h"]
 
 commandCheck :: Parser (IO ())
 commandCheck =
   withAdvisory (const $ T.putStrLn "no error")
   <$> optional (argument str (metavar "FILE"))
+  <**> helper
 
 commandRender :: Parser (IO ())
 commandRender =
   withAdvisory (T.putStrLn . renderAdvisoryHtml)
   <$> optional (argument str (metavar "FILE"))
+  <**> helper
+
+commandHelp :: Parser (IO ())
+commandHelp =
+  ( \mCmd ->
+      let args = maybe id (:) mCmd ["-h"]
+      in void $ handleParseResult $ execParserPure defaultPrefs cliOpts args
+  )
+  <$> optional (argument str (metavar "COMMAND"))
 
 withAdvisory :: (Advisory -> IO ()) -> Maybe FilePath -> IO ()
 withAdvisory go file = do

--- a/code/hsec-tools/hsec-tools.cabal
+++ b/code/hsec-tools/hsec-tools.cabal
@@ -58,7 +58,8 @@ executable hsec-tools
     build-depends:    hsec-tools,
                       base >=4.14 && < 4.19,
                       text >= 1.2 && < 3,
-                      optparse-applicative == 0.17.* || == 0.18.*
+                      optparse-applicative == 0.17.* || == 0.18.*,
+                      filepath >= 1.4 && < 1.5
     hs-source-dirs:   app
     default-language: Haskell2010
     ghc-options:      -Wall


### PR DESCRIPTION
Fixes: https://github.com/haskell/security-advisories/issues/40

```
commit 3598b43f1f4757763eb66c8ac7b1f9480b3a639d
Author: Fraser Tweedale <frase@frase.id.au>
Date:   Tue Jun 13 21:42:58 2023 +1000

    tools(check): check filename matches advisory ID
    
    We expect advisories in files name `HSEC-YYYY-NNNN.md`.  The
    advisory ID also appears in the TOML metadata.  Add a check that the
    ID is the same in both places.
    
    If the filename does not match the expected pattern, we allow it.
    The heuristic is ``"HSEC-" `isPrefixOf```, to allow for files that
    do not match the pattern (for instance, example advisories).  This
    is quite a crude heuristic, and should probably be improved
    somewhat, to catch more subtle errors.  But this will do for now.
    
    Fixes: https://github.com/haskell/security-advisories/issues/40

commit 47c8013a674f5c2989df96ad56e0a44fc9e47d97
Author: Fraser Tweedale <frase@frase.id.au>
Date:   Tue Jun 13 21:08:28 2023 +1000

    tools: improve command help
    
    Add the `-h`/`--help` option to each of the subcommands (except
    `help` itself).  Also update `help` to take an optional command
    name, so that `hsec-tools help foo` means the same thing as
    `hsec-tools foo --help`

commit c0e66c6928a30b08b2397f12a3602417f301822c
Author: Fraser Tweedale <frase@frase.id.au>
Date:   Tue Jun 13 21:05:59 2023 +1000

    tools: allow specifying input file by name
    
    Update the `check` and `render` commands to accept an optional
    filename argument.  This allows specifying the input file by name.
    
    This is also a step towards implementing a check that the filename
    matches the `id` in the advisory metadata.

```
