### PR TITLE
tools: OSV model improvements

### DIFF
--- a/EXAMPLE_ADVISORY.md
+++ b/EXAMPLE_ADVISORY.md
@@ -4,7 +4,6 @@
 id = "HSEC-0000-0000"
 package = "package-name"
 date = 2021-01-31
-url = "https://example.com"
 cwe = []
 cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 keywords = ["example", "freeform", "keywords"]
@@ -20,6 +19,10 @@ keywords = ["example", "freeform", "keywords"]
 [[versions]]
 introduced = "1.1.0"
 fixed = "1.2.0.5"
+
+[[references]]
+type = "ARTICLE"
+url = "https://example.com"
 ```
 
 # Advisory Template - Title Goes Here

--- a/README.md
+++ b/README.md
@@ -34,10 +34,6 @@ package = "acme-broken"
 # Disclosure date of the advisory as an RFC 3339 date (mandatory)
 date = 2021-01-31
 
-# URL to a long-form description of this issue, e.g. a GitHub issue/PR,
-# a change log entry, or a blogpost announcing the release (optional)
-url = "https://github.com/username/package/issues/123"
-
 # Optional: Classification of the advisory with respect to the Common Weakness Enumeration.
 cwe = [820]
 
@@ -56,6 +52,16 @@ keywords = ["ssl", "mitm"]
 # Related vulnerabilities (optional)
 # e.g. CVE for a C library wrapped by a Haskell library
 #related = ["CVE-2018-YYYY", "CVE-2018-ZZZZ"]
+
+# References to articles, issues/PRs, etc.  Recognised types:
+# ADVISORY, ARTICLE, DETECTION, DISCUSSION, REPORT,
+# FIX, INTRODUCED, PACKAGE, EVIDENCE, WEB
+[[references]]
+type = "REPORT"
+url = "https://github.com/username/package/issues/123"
+[[references]]
+type = "FIX"
+url = "https://github.com/username/package/pull/139"
 
 # Optional: metadata which narrows the scope of what this advisory affects
 [affected]

--- a/advisories/hackage/aeson/HSEC-2023-0001.md
+++ b/advisories/hackage/aeson/HSEC-2023-0001.md
@@ -3,11 +3,20 @@
 id = "HSEC-2023-0001"
 package = "aeson"
 date = 2021-09-11
-url = "https://cs-syd.eu/posts/2021-09-11-json-vulnerability"
 cwe = [328, 400]
 cvss = "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
 keywords = ["json", "dos"]
 aliases = ["CVE-2022-3433"]
+
+[[references]]
+type = "ARTICLE"
+url = "https://cs-syd.eu/posts/2021-09-11-json-vulnerability"
+[[references]]
+type = "ARTICLE"
+url = "https://frasertweedale.github.io/blog-fp/posts/2021-10-12-aeson-hash-flooding-protection.html"
+[[references]]
+type = "DISCUSSION"
+url = "https://github.com/haskell/aeson/issues/864"
 
 [[versions]]
 introduced = "0.4.0.0"

--- a/code/hsec-tools/hsec-tools.cabal
+++ b/code/hsec-tools/hsec-tools.cabal
@@ -28,7 +28,8 @@ tested-with:
 
 library
     exposed-modules:
-                      Security.Advisories
+                      Security.Advisories,
+                      Security.OSV
     build-depends:    base >=4.14 && < 4.19,
                       text >= 1.2 && < 3,
                       time >= 1.9 && < 1.14,
@@ -36,7 +37,8 @@ library
                       mtl >= 2.2 && < 2.4,
                       containers >= 0.6 && < 0.7,
                       commonmark ^>= 0.2.2,
-                      toml-reader ^>= 0.1 || ^>= 0.2
+                      toml-reader ^>= 0.1 || ^>= 0.2,
+                      aeson >= 2
     hs-source-dirs:   src
     default-language: Haskell2010
     ghc-options:      -Wall

--- a/code/hsec-tools/src/Security/OSV.hs
+++ b/code/hsec-tools/src/Security/OSV.hs
@@ -1,0 +1,223 @@
+-- | This module contains the OSV datatype and its ToJSON instance.
+-- The module was initialized with http://json-to-haskell.chrispenner.ca/
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Security.OSV where
+
+import Data.Aeson (ToJSON(..), FromJSON(..), Value(..), (.:), (.=), object)
+import Data.Aeson.Types (prependFailure, typeMismatch)
+import Data.Text (Text)
+
+data Affected = Affected
+  { affectedRanges :: [Ranges]
+  , affectedPackage :: Package
+  , affectedEcosystemSpecific :: EcosystemSpecific
+  , affectedDatabaseSpecific :: DatabaseSpecific
+  } deriving (Show, Eq, Ord)
+
+data Affects = Affects
+  { affectsOs :: [Value]
+  , affectsArch :: [Value]
+  , affectsFunctions :: [Value]
+  } deriving (Show, Eq, Ord)
+
+data DatabaseSpecific = DatabaseSpecific
+  { databaseSpecificCvss :: Maybe Value
+  , databaseSpecificCategories :: [Value]
+  , databaseSpecificInformational :: Text
+  } deriving (Show, Eq, Ord)
+
+newtype EcosystemSpecific = EcosystemSpecific
+  { ecosystemSpecificAffects :: Affects
+  } deriving (Show, Eq, Ord)
+
+newtype Events = Events
+  { eventsIntroduced :: Text
+  } deriving (Show, Eq, Ord)
+
+data Model = Model
+  { modelDetails :: Text
+  , modelId :: Text
+  , modelSummary :: Text
+  , modelRelated :: [Value]
+  , modelAffected :: [Affected]
+  , modelAliases :: [Value]
+  , modelPublished :: Text
+  , modelReferences :: [References]
+  , modelSeverity :: [Value]
+  , modelModified :: Text
+  } deriving (Show, Eq, Ord)
+
+data Package = Package
+  { packageName :: Text
+  , packageEcosystem :: Text
+  , packagePurl :: Text
+  } deriving (Show, Eq, Ord)
+
+data Ranges = Ranges
+  { rangesEvents :: [Events]
+  , rangesType :: Text
+  } deriving (Show, Eq, Ord)
+
+data References = References
+  { referencesType :: Text
+  , referencesUrl :: Text
+  } deriving (Show, Eq, Ord)
+
+instance ToJSON Affected where
+  toJSON Affected{..} = object
+    [ "ranges" .= affectedRanges
+    , "package" .= affectedPackage
+    , "ecosystem_specific" .= affectedEcosystemSpecific
+    , "database_specific" .= affectedDatabaseSpecific
+    ]
+
+instance ToJSON Affects where
+  toJSON Affects{..} = object
+    [ "os" .= affectsOs
+    , "arch" .= affectsArch
+    , "functions" .= affectsFunctions
+    ]
+
+instance ToJSON DatabaseSpecific where
+  toJSON DatabaseSpecific{..} = object
+    [ "cvss" .= databaseSpecificCvss
+    , "categories" .= databaseSpecificCategories
+    , "informational" .= databaseSpecificInformational
+    ]
+
+instance ToJSON EcosystemSpecific where
+  toJSON EcosystemSpecific{..} = object
+    [ "affects" .= ecosystemSpecificAffects
+    ]
+
+instance ToJSON Events where
+  toJSON Events{..} = object
+    [ "introduced" .= eventsIntroduced
+    ]
+
+instance ToJSON Model where
+  toJSON Model{..} = object
+    [ "details" .= modelDetails
+    , "id" .= modelId
+    , "summary" .= modelSummary
+    , "related" .= modelRelated
+    , "affected" .= modelAffected
+    , "aliases" .= modelAliases
+    , "published" .= modelPublished
+    , "references" .= modelReferences
+    , "severity" .= modelSeverity
+    , "modified" .= modelModified
+    ]
+
+instance ToJSON Package where
+  toJSON Package{..} = object
+    [ "name" .= packageName
+    , "ecosystem" .= packageEcosystem
+    , "purl" .= packagePurl
+    ]
+
+instance ToJSON Ranges where
+  toJSON Ranges{..} = object
+    [ "events" .= rangesEvents
+    , "type" .= rangesType
+    ]
+
+instance ToJSON References where
+  toJSON References{..} = object
+    [ "type" .= referencesType
+    , "url" .= referencesUrl
+    ]
+
+instance FromJSON Affected where
+  parseJSON (Object v) = do
+    affectedRanges <- v .: "ranges"
+    affectedPackage <- v .: "package"
+    affectedEcosystemSpecific <- v .: "ecosystem_specific"
+    affectedDatabaseSpecific <- v .: "database_specific"
+    pure $ Affected{..}
+  parseJSON invalid = do
+    prependFailure "parsing Affected failed, "
+      (typeMismatch "Object" invalid)
+
+instance FromJSON Affects where
+  parseJSON (Object v) = do
+    affectsOs <- v .: "os"
+    affectsArch <- v .: "arch"
+    affectsFunctions <- v .: "functions"
+    pure $ Affects{..}
+  parseJSON invalid = do
+    prependFailure "parsing Affects failed, "
+      (typeMismatch "Object" invalid)
+
+instance FromJSON DatabaseSpecific where
+  parseJSON (Object v) = do
+    databaseSpecificCvss <- v .: "cvss"
+    databaseSpecificCategories <- v .: "categories"
+    databaseSpecificInformational <- v .: "informational"
+    pure $ DatabaseSpecific{..}
+  parseJSON invalid = do
+    prependFailure "parsing DatabaseSpecific failed, "
+      (typeMismatch "Object" invalid)
+
+instance FromJSON EcosystemSpecific where
+  parseJSON (Object v) = do
+    ecosystemSpecificAffects <- v .: "affects"
+    pure $ EcosystemSpecific{..}
+  parseJSON invalid = do
+    prependFailure "parsing EcosystemSpecific failed, "
+      (typeMismatch "Object" invalid)
+
+instance FromJSON Events where
+  parseJSON (Object v) = do
+    eventsIntroduced <- v .: "introduced"
+    pure $ Events{..}
+  parseJSON invalid = do
+    prependFailure "parsing Events failed, "
+      (typeMismatch "Object" invalid)
+
+instance FromJSON Model where
+  parseJSON (Object v) = do
+    modelDetails <- v .: "details"
+    modelId <- v .: "id"
+    modelSummary <- v .: "summary"
+    modelRelated <- v .: "related"
+    modelAffected <- v .: "affected"
+    modelAliases <- v .: "aliases"
+    modelPublished <- v .: "published"
+    modelReferences <- v .: "references"
+    modelSeverity <- v .: "severity"
+    modelModified <- v .: "modified"
+    pure $ Model{..}
+  parseJSON invalid = do
+    prependFailure "parsing Model failed, "
+      (typeMismatch "Object" invalid)
+
+instance FromJSON Package where
+  parseJSON (Object v) = do
+    packageName <- v .: "name"
+    packageEcosystem <- v .: "ecosystem"
+    packagePurl <- v .: "purl"
+    pure $ Package{..}
+  parseJSON invalid = do
+    prependFailure "parsing Package failed, "
+      (typeMismatch "Object" invalid)
+
+instance FromJSON Ranges where
+  parseJSON (Object v) = do
+    rangesEvents <- v .: "events"
+    rangesType <- v .: "type"
+    pure $ Ranges{..}
+  parseJSON invalid = do
+    prependFailure "parsing Ranges failed, "
+      (typeMismatch "Object" invalid)
+
+instance FromJSON References where
+  parseJSON (Object v) = do
+    referencesType <- v .: "type"
+    referencesUrl <- v .: "url"
+    pure $ References{..}
+  parseJSON invalid = do
+    prependFailure "parsing References failed, "
+      (typeMismatch "Object" invalid)


### PR DESCRIPTION
This PR is based on #33, further refining the `Model` type and the encode/decode behaviour.

- Add `schema_version` field
- Add `withdrawn` field
- Add `credits` field (a `[Value]` for now, to be refined later)
- Make all optional fields optional
- Make `aliases` and `related` fields a list of strings (instead of arbitrary values)
- For list fields, interpret missing field as empty list (and omit empty lists when converting to JSON)
- Parameterise `Model` over the "database_specific" payload type. A naïve consumer can just use `Model Value`
- Add dedicated `ReferenceType` type