### PR TITLE
lib/advisories: parse into pandoc AST

### DIFF
--- a/code/hsec-tools/app/Main.hs
+++ b/code/hsec-tools/app/Main.hs
@@ -42,7 +42,7 @@ commandCheck =
 
 commandRender :: Parser (IO ())
 commandRender =
-  withAdvisory (\_ -> T.putStrLn . renderAdvisoryHtml)
+  withAdvisory (\_ -> T.putStrLn . advisoryHtml)
   <$> optional (argument str (metavar "FILE"))
   <**> helper
 

--- a/code/hsec-tools/hsec-tools.cabal
+++ b/code/hsec-tools/hsec-tools.cabal
@@ -38,7 +38,9 @@ library
                       containers >= 0.6 && < 0.7,
                       commonmark ^>= 0.2.2,
                       toml-reader ^>= 0.1 || ^>= 0.2,
-                      aeson >= 2
+                      aeson >= 2,
+                      pandoc-types >= 1.22 && < 2,
+                      commonmark-pandoc >= 0.2 && < 0.3
     hs-source-dirs:   src
     default-language: Haskell2010
     ghc-options:      -Wall


### PR DESCRIPTION
Instead of our hand-rolled document AST, parse the advisory content into a `Pandoc` document via *commonmark-pandoc*.  Store the `Pandoc` value in the `advisoryPandoc` field.

We continue (for now) to retain the `advisoryHtml` field.  It now displays the raw TOML block instead of a prettier HTML table - a mild regression.  But we expect to remove this field in the future, when we implement full site rendering for the advisory database.

Fixes: https://github.com/haskell/security-advisories/issues/43