### PR TITLE
Report biscuit-haskell CVE-2022-31053 (#32)

### DIFF
--- a/advisories/hackage/biscuit-haskell/HSEC-2022-0001.md
+++ b/advisories/hackage/biscuit-haskell/HSEC-2022-0001.md
@@ -1,0 +1,29 @@
+```toml
+[advisory]
+id = "HSEC-2022-0001"
+package = "biscuit-haskell"
+date = 2022-06-13
+cwe = [347]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+keywords = ["crypto"]
+aliases = ["CVE-2022-31053"]
+
+[[references]]
+type = "REPORT"
+url = "https://eprint.iacr.org/2020/1484"
+[[references]]
+type = "ADVISORY"
+url = "https://github.com/biscuit-auth/biscuit/security/advisories/GHSA-75rw-34q6-72cr"
+
+[[versions]]
+introduced = "0.1.0.0"
+fixed = "0.2.0.0"
+```
+
+# Improper Verification of Cryptographic Signature
+
+The Biscuit specification version 1 contains a vulnerable algorithm that allows
+malicious actors to forge valid ?-signatures. Such an attack would allow an
+attacker to create a token with any access level. The version 2 of the
+specification mandates a different algorithm than gamma signatures and as such
+is not affected by this vulnerability.


### PR DESCRIPTION
---

## Advisory

- [x] It's not duplicated
- [x] All fields are filled
- [x] It is validated by `hsec-tools`
