### PR TITLE
lib/advisories: read timestamps from Git history

### DIFF
--- a/EXAMPLE_ADVISORY.md
+++ b/EXAMPLE_ADVISORY.md
@@ -3,7 +3,6 @@
 [advisory]
 id = "HSEC-0000-0000"
 package = "package-name"
-date = 2021-01-31
 cwe = []
 cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 keywords = ["example", "freeform", "keywords"]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ id = "HSEC-0000-0000"
 # Name of the affected package on Hackage (mandatory)
 package = "acme-broken"
 
-# Disclosure date of the advisory as an RFC 3339 date (mandatory)
+# Publication date of the advisory as an RFC 3339 date.
+# DO NOT INCLUDE THIS in files committed to Git.
+# It will be derived from the Git commit history.
 date = 2021-01-31
 
 # Optional: Classification of the advisory with respect to the Common Weakness Enumeration.

--- a/advisories/hackage/aeson/HSEC-2023-0001.md
+++ b/advisories/hackage/aeson/HSEC-2023-0001.md
@@ -2,7 +2,6 @@
 [advisory]
 id = "HSEC-2023-0001"
 package = "aeson"
-date = 2021-09-11
 cwe = [328, 400]
 cvss = "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
 keywords = ["json", "dos"]

--- a/advisories/hackage/biscuit-haskell/HSEC-2023-0002.md
+++ b/advisories/hackage/biscuit-haskell/HSEC-2023-0002.md
@@ -2,7 +2,6 @@
 [advisory]
 id = "HSEC-2023-0002"
 package = "biscuit-haskell"
-date = 2022-06-13
 cwe = [347]
 cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 keywords = ["crypto"]

--- a/advisories/hackage/xmonad-contrib/HSEC-2023-0003.md
+++ b/advisories/hackage/xmonad-contrib/HSEC-2023-0003.md
@@ -2,7 +2,6 @@
 [advisory]
 id = "HSEC-2023-0003"
 package = "xmonad-contrib"
-date = 2013-09-11
 cwe = [94]
 cvss = "CVSS:2.0/AV:N/AC:L/Au:N/C:P/I:P/A:P"
 keywords = ["code", "injection"]

--- a/code/hsec-tools/hsec-tools.cabal
+++ b/code/hsec-tools/hsec-tools.cabal
@@ -29,9 +29,12 @@ tested-with:
 library
     exposed-modules:    Security.Advisories
                       , Security.Advisories.Definition
+                      , Security.Advisories.Git
                       , Security.Advisories.Parse
                       , Security.OSV
     build-depends:    base >=4.14 && < 4.19,
+                      filepath >= 1.4 && < 1.5,
+                      process >= 1.6 && < 1.7,
                       text >= 1.2 && < 3,
                       time >= 1.9 && < 1.14,
                       Cabal >= 3.2.1.0 && < 3.11,

--- a/code/hsec-tools/src/Security/Advisories/Definition.hs
+++ b/code/hsec-tools/src/Security/Advisories/Definition.hs
@@ -7,12 +7,12 @@ module Security.Advisories.Definition
   , Architecture(..)
   , AffectedVersionRange(..)
   , OS(..)
-  , Date(..)
   , Keyword(..)
   )
   where
 
 import Data.Text (Text)
+import Data.Time (ZonedTime)
 import Distribution.Types.VersionRange (VersionRange)
 
 import Text.Pandoc.Definition (Pandoc)
@@ -21,8 +21,9 @@ import Security.OSV (Reference)
 
 data Advisory = Advisory
   { advisoryId :: Text
+  , advisoryModified :: ZonedTime
+  , advisoryPublished :: ZonedTime
   , advisoryPackage :: Text
-  , advisoryDate :: Date
   , advisoryCWEs :: [CWE]
   , advisoryKeywords :: [Keyword]
   , advisoryAliases :: [Text]
@@ -77,9 +78,6 @@ data OS
   | Android
   | NetBSD
   | OpenBSD
-  deriving stock (Show)
-
-data Date = Date {dateYear :: Integer, dateMonth :: Int, dateDay :: Int}
   deriving stock (Show)
 
 newtype Keyword = Keyword Text

--- a/code/hsec-tools/src/Security/Advisories/Git.hs
+++ b/code/hsec-tools/src/Security/Advisories/Git.hs
@@ -1,0 +1,52 @@
+{-|
+
+Helpers for deriving advisory metadata from a Git repo.
+
+-}
+module Security.Advisories.Git
+  ( AdvisoryGitInfo(..)
+  , GitError(..)
+  , getAdvisoryGitInfo
+  )
+  where
+
+import Data.Time (ZonedTime)
+import Data.Time.Format.ISO8601 (iso8601ParseM)
+import System.Exit (ExitCode(ExitSuccess))
+import System.FilePath (splitFileName)
+import System.Process (readProcessWithExitCode)
+
+data AdvisoryGitInfo = AdvisoryGitInfo
+  { firstAppearanceCommitDate :: ZonedTime
+  , lastModificationCommitDate :: ZonedTime
+  }
+
+data GitError
+  = GitProcessError ExitCode String String -- ^ exit code, stdout and stderr
+  | GitTimeParseError String -- ^ unable to parse this input as a datetime
+  deriving (Show)
+
+getAdvisoryGitInfo :: FilePath -> IO (Either GitError AdvisoryGitInfo)
+getAdvisoryGitInfo path = do
+  let (dir, file) = splitFileName path
+  (status, stdout, stderr) <- readProcessWithExitCode
+    "git"
+    [ "-C", dir
+    , "log"
+    , "--pretty=format:%cI"  -- print committer date
+    , "--find-renames"
+    , file
+    ]
+    "" -- standard input
+  let timestamps = filter (not . null) $ lines stdout
+  case status of
+    ExitSuccess | not (null timestamps) ->
+      pure $ AdvisoryGitInfo
+        <$> parseTime (last timestamps)  -- first commit is last line
+        <*> parseTime (head timestamps)  -- most recent commit is first line
+    _ ->
+      -- `null lines` should not happen, but if it does we treat it
+      -- the same as `ExitFailure`
+      pure . Left $ GitProcessError status stdout stderr
+  where
+    parseTime s = maybe (Left $ GitTimeParseError s) Right $ iso8601ParseM s


### PR DESCRIPTION
***Note:** there are 4 nice, self-contained commits in this PR.  The best approach for review would be to review each commit in sequence.*

Update hsec-tools to read the publication and modification
timestamps from the Git history.  The heuristic uses the commit time
of the first appearance of the file as the publication date, and the
most recent commit that changed the file as the modification date.
Rewrites are followed at Git's default similarity threshold.

The behaviour to query the Git repository is provided in the new
module `Security.Advisories.Git`.

Failures running Git or parsing the output are ignored (e.g. if the
given file is not in a Git repository).  This supports use of the
tool outside the Git context.  The caveat is that the advisory TOML
header must have explicit `"date"` and (if different from `"date"`),
`"modified"` fields.

Also update existing advisories to remove the `"date"` field.
    
