### PR TITLE
Update link to template on CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,5 +67,5 @@ A: We do not presently handle embargoed vulnerabilities. Please ensure embargoes
    them here.
 
 [Pull Request]: https://github.com/haskell/security-advisories/pulls
-[TOML advisory template]: https://github.com/haskell/security-advisories/pulls#advisory-format
+[TOML advisory template]: https://github.com/haskell/security-advisories/blob/main/README.md#advisory-format
 [example]: https://raw.githubusercontent.com/haskell/security-advisories/main/EXAMPLE_ADVISORY.md


### PR DESCRIPTION
This came up while following the instructions to test the project. The existing link just goes to the pull request section.

