### PR TITLE
fix(advisory): rename HSEC-2022-0001 to HSEC-2023-0002

### DIFF
--- a/advisories/hackage/biscuit-haskell/HSEC-2023-0002.md
+++ b/advisories/hackage/biscuit-haskell/HSEC-2023-0002.md
@@ -1,6 +1,6 @@
 ```toml
 [advisory]
-id = "HSEC-2022-0001"
+id = "HSEC-2023-0002"
 package = "biscuit-haskell"
 date = 2022-06-13
 cwe = [347]


### PR DESCRIPTION
---

## Advisory

- [x] It's not duplicated
- [x] All fields are filled
- [x] It is validated by `hsec-tools`
