### PR TITLE
lib/advisories: add advisoryDetails field (and parse it)

### DIFF
--- a/code/hsec-tools/hsec-tools.cabal
+++ b/code/hsec-tools/hsec-tools.cabal
@@ -44,6 +44,7 @@ library
                       toml-reader ^>= 0.1 || ^>= 0.2,
                       aeson >= 2,
                       pandoc-types >= 1.22 && < 2,
+                      parsec >= 3 && < 4,
                       commonmark-pandoc >= 0.2 && < 0.3
     hs-source-dirs:   src
     default-language: Haskell2010

--- a/code/hsec-tools/src/Security/Advisories/Definition.hs
+++ b/code/hsec-tools/src/Security/Advisories/Definition.hs
@@ -36,6 +36,9 @@ data Advisory = Advisory
   , advisoryPandoc :: Pandoc  -- ^ Parsed document, without TOML front matter
   , advisoryHtml :: Text
   , advisorySummary :: Text
+    -- ^ A one-line, English textual summary of the vulnerability
+  , advisoryDetails :: Text
+    -- ^ Details of the vulnerability (CommonMark), without TOML front matter
   }
   deriving stock (Show)
 


### PR DESCRIPTION
Add the `advisoryDetails :: Text` field, which reflects the OSV `details` field.  It is intended to be CommonMark content.

When parsing, use a nasty hack to get the source range of the TOML header, so that we can drop it and store the remainder of the input as the `advisoryDetails`.