### PR TITLE
lib/osv: more schema alignment improvements, and other cleanups

### DIFF
--- a/code/hsec-tools/src/Security/OSV.hs
+++ b/code/hsec-tools/src/Security/OSV.hs
@@ -30,12 +30,6 @@ data Affected dbSpecific ecosystemSpecific rangeDbSpecific = Affected
   , affectedDatabaseSpecific :: Maybe dbSpecific
   } deriving (Show, Eq)
 
-data Affects = Affects
-  { affectsOs :: [Value]
-  , affectsArch :: [Value]
-  , affectsFunctions :: [Value]
-  } deriving (Show, Eq, Ord)
-
 data Event a
   = EventIntroduced a
   | EventFixed a
@@ -342,13 +336,6 @@ instance
       omitEmptyList _ [] = []
       omitEmptyList k xs = [k .= xs]
 
-instance ToJSON Affects where
-  toJSON Affects{..} = object
-    [ "os" .= affectsOs
-    , "arch" .= affectsArch
-    , "functions" .= affectsFunctions
-    ]
-
 instance
   ( ToJSON dbSpecific
   , ToJSON affectedEcosystemSpecific
@@ -403,16 +390,6 @@ instance
     pure $ Affected{..}
   parseJSON invalid = do
     prependFailure "parsing Affected failed, "
-      (typeMismatch "Object" invalid)
-
-instance FromJSON Affects where
-  parseJSON (Object v) = do
-    affectsOs <- v .: "os"
-    affectsArch <- v .: "arch"
-    affectsFunctions <- v .: "functions"
-    pure $ Affects{..}
-  parseJSON invalid = do
-    prependFailure "parsing Affects failed, "
       (typeMismatch "Object" invalid)
 
 -- | Explicit parser for 'UTCTime', stricter than the @FromJSON@

--- a/code/hsec-tools/src/Security/OSV.hs
+++ b/code/hsec-tools/src/Security/OSV.hs
@@ -149,7 +149,7 @@ instance ToJSON Severity where
 data Package = Package
   { packageName :: Text
   , packageEcosystem :: Text
-  , packagePurl :: Text
+  , packagePurl :: Maybe Text  -- TODO refine type
   } deriving (Show, Eq, Ord)
 
 data Range dbSpecific
@@ -366,11 +366,11 @@ instance
       omitEmptyList xs = Just xs
 
 instance ToJSON Package where
-  toJSON Package{..} = object
+  toJSON Package{..} = object $
     [ "name" .= packageName
     , "ecosystem" .= packageEcosystem
-    , "purl" .= packagePurl
     ]
+    <> maybe [] (pure . ("purl" .=)) packagePurl
 
 instance ToJSON Reference where
   toJSON Reference{..} = object
@@ -434,7 +434,7 @@ instance FromJSON Package where
   parseJSON (Object v) = do
     packageName <- v .: "name"
     packageEcosystem <- v .: "ecosystem"
-    packagePurl <- v .: "purl"
+    packagePurl <- v .:? "purl"
     pure $ Package{..}
   parseJSON invalid = do
     prependFailure "parsing Package failed, "

--- a/code/hsec-tools/src/Security/OSV.hs
+++ b/code/hsec-tools/src/Security/OSV.hs
@@ -3,7 +3,29 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE OverloadedStrings #-}
-module Security.OSV where
+
+module Security.OSV
+  (
+  -- * Top-level data type
+    Model(..)
+  , newModel
+  , newModel'
+  , defaultSchemaVersion
+
+  -- * Subsidiary data types
+  , Affected(..)
+  , Credit(..)
+  , CreditType(..)
+  , creditTypes
+  , Event(..)
+  , Package(..)
+  , Range(..)
+  , Reference(..)
+  , ReferenceType(..)
+  , referenceTypes
+  , Severity(..)
+  )
+  where
 
 import Control.Applicative ((<|>))
 import Control.Monad (when)


### PR DESCRIPTION
**Note**: 4 self-contained, sequential commits.  Recommend to review each in sequence.

```
commit 4519a7605b20e57d3c0e0fab95d5862464c78fbb
Author: Fraser Tweedale <frase@frase.id.au>
Date:   Wed Jun 21 16:27:44 2023 +1000

    lib/osv: abstract over database/ecosystem-specific fields
    
    A general-purpose OSV library should not hardcode anything about the
    `database_specific` or `ecosystem_specific` fields.  Abstract over
    these.
    
    A naïve consumer can parse `Model Value Value Value Value` for no
    loss of information.
    
    A producer can instantiate unused database/ecosystem-specific fields
    at `Void`.  `()` is not recommended, because `Just ()` will
    serialise as an empty JSON array.

commit c6a6d09ef5cbb91b18fd68b90a27968f9fa056a4
Author: Fraser Tweedale <frase@frase.id.au>
Date:   Thu Jun 22 23:31:14 2023 +1000

    lib/osv: remove unused Affects data type
    
    We might use something like the `Affects` data type the HSEC
    `database_specific` or Hackage `ecosystem_specific` fields.  But
    this does not belong in the general-purpose OSV module.  So remove
    it.  (It might get reincarnated elsewhere, in a later commit).

commit a9e621842dfdc97e7591db719b199761bfb28e43
Author: Fraser Tweedale <frase@frase.id.au>
Date:   Thu Jun 22 23:33:36 2023 +1000

    lib/osv: make "purl" field optional, per spec

commit 0fa58fbe8d540016eb00a862ed8716857c954b0c
Author: Fraser Tweedale <frase@frase.id.au>
Date:   Thu Jun 22 23:37:58 2023 +1000

    lib/osv: add export list to Security.OSV
```
