### PR TITLE
HSEC-2023-0003: update versions and references

### DIFF
--- a/advisories/hackage/xmonad-contrib/HSEC-2023-0003.md
+++ b/advisories/hackage/xmonad-contrib/HSEC-2023-0003.md
@@ -8,15 +8,18 @@ keywords = ["code", "injection"]
 aliases = ["CVE-2013-1436"]
 
 [[references]]
-type = "ARTICLE"
-url = "http://security.gentoo.org/glsa/glsa-201405-28.xml"
+type = "ADVISORY"
+url = "https://security.gentoo.org/glsa/201405-28"
 [[references]]
 type = "DISCUSSION"
 url = "http://www.openwall.com/lists/oss-security/2013/07/26/5"
+[[references]]
+type = "FIX"
+url = "https://github.com/xmonad/xmonad-contrib/commit/d3b2a01e3d01ac628e7a3139dd55becbfa37cf51"
 
 [[versions]]
-introduced = "0.11.2.0"
-fixed = "0.11.3.0"
+introduced = "0.5"
+fixed = "0.11.2"
 ```
 
 # code injection in xmonad-contrib


### PR DESCRIPTION
Refine the type of an existing reference, and add a FIX reference.

Update the affected versions.  The fix version is actually v0.11.2, and the introduced version is v0.5 or *possibly earlier*.  A big refactor happened before v0.5 and I'm unsure if previous versions were affected.  In any case, v0.5 is the earliest version on Hackage.