### PR TITLE
fix(tool): rely on nixos-unstable to use cache

### DIFF
--- a/code/hsec-tools/flake.lock
+++ b/code/hsec-tools/flake.lock
@@ -20,15 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687289913,
-        "narHash": "sha256-XObX/pwJ0lVxT/b3p+I2+BkqUr1qndQogHcBKUIRQFQ=",
+        "lastModified": 1687502512,
+        "narHash": "sha256-dBL/01TayOSZYxtY4cMXuNCBk8UMLoqRZA+94xiFpJA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "34038fa36a74ad98f1531e4136d6d9981e6fe6b0",
+        "rev": "3ae20aa58a6c0d1ca95c9b11f59a2d12eebc511f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/code/hsec-tools/flake.nix
+++ b/code/hsec-tools/flake.nix
@@ -2,7 +2,7 @@
   description = "hsec-tools";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
---

## hsec-tools

- [x] Previous advisories are still valid
