### PR TITLE
lib/advisories: support multiple packages per advisory

### DIFF
--- a/EXAMPLE_ADVISORY.md
+++ b/EXAMPLE_ADVISORY.md
@@ -2,20 +2,21 @@
 
 [advisory]
 id = "HSEC-0000-0000"
-package = "package-name"
 cwe = []
-cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 keywords = ["example", "freeform", "keywords"]
 # aliases = ["CVE-2022-XXXX"]
 # related = ["CVE-2022-YYYY", "CVE-2022-ZZZZ"]
 
-[affected]
+# You can declare multiple affected packages
+[[affected]]
+package = "package-name"
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 # arch = ["x86", "x86_64"]
 # os = ["mingw32"]
 # declarations = { "Acme.Broken.function" = ">= 1.1.0 && < 1.2.0", "Acme.Broken.renamedFunction" = ">= 1.2.0 && < 1.2.0.5"}
 
-# Versions affected by the vulnerability. Multiple range should not overlap.
-[[versions]]
+# Versions affected by the vulnerability. Multiple ranges should not overlap.
+[[affected.versions]]
 introduced = "1.1.0"
 fixed = "1.2.0.5"
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,6 @@ to remove the explanatory comments for each field.
 # identifier e.g. HSEC-2022-0001. Please use "HSEC-0000-0000" in PRs.
 id = "HSEC-0000-0000"
 
-# Name of the affected package on Hackage (mandatory)
-package = "acme-broken"
-
 # Publication date of the advisory as an RFC 3339 date.
 # DO NOT INCLUDE THIS in files committed to Git.
 # It will be derived from the Git commit history.
@@ -38,11 +35,6 @@ date = 2021-01-31
 
 # Optional: Classification of the advisory with respect to the Common Weakness Enumeration.
 cwe = [820]
-
-# Mandatory: a Common Vulnerability Scoring System score. More information
-# can be found on the CVSS website, https://www.first.org/cvss/.
-# The committee will assist advisory authors in constructing an appropriate CVSS if necessary.
-cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 # Freeform keywords which describe this vulnerability (optional)
 keywords = ["ssl", "mitm"]
@@ -65,23 +57,34 @@ url = "https://github.com/username/package/issues/123"
 type = "FIX"
 url = "https://github.com/username/package/pull/139"
 
-# Optional: metadata which narrows the scope of what this advisory affects
-[affected]
-# CPU architectures impacted by this vulnerability (optional).
+# Affected package(s).  You can declare one or more packages.
+# Sub-fields are `package`, `cvss`, `arch`, `os`, `declarations`
+# and the `versions` table.
+[[affected]]
+
+# Mandatory: name of the affected package on Hackage
+package = "acme-broken"
+
+# Mandatory: a Common Vulnerability Scoring System score. More information
+# can be found on the CVSS website, https://www.first.org/cvss/.
+# The committee will assist advisory authors in constructing an appropriate CVSS if necessary.
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+
+# Optional: CPU architectures impacted by this vulnerability
 # Only use this if the vulnerability is specific to a particular CPU architecture,
 # e.g. the vulnerability is in x86 assembly.
 # For a list of CPU architecture strings, see the documentation for System.Info.arch:
 # <https://hackage.haskell.org/package/base-4.16.1.0/docs/System-Info.html>
 #arch = ["x86", "x86_64"]
 
-# Operating systems impacted by this vulnerability (optional)
+# Optional: Operating systems impacted by this vulnerability
 # Only use this if the vulnerable is specific to a particular OS, e.g. it was
 # located in a binding to a Windows-specific API.
 # For a list of OS strings, see the documentation for System.Info.os:
 # <https://hackage.haskell.org/package/base-4.16.1.0/docs/System-Info.html>
 #os = ["mingw32"]
 
-# Table of canonical paths to vulnerable declarations in the package (optional)
+# Optional: Table of canonical paths to vulnerable declarations in the package
 # that describes which versions impacted by this advisory used that particular
 # name (e.g. if an affected function or datatype was renamed between versions).
 # The path syntax is the module import path, without any type signatures or
@@ -89,7 +92,7 @@ url = "https://github.com/username/package/pull/139"
 #declarations = { "Acme.Broken.function" = ">= 1.1.0 && < 1.2.0", "Acme.Broken.renamedFunction" = ">= 1.2.0 && < 1.2.0.5"}
 
 # Versions affected by the vulnerability. Multiple range should not overlap.
-[[versions]]
+[[affected.versions]]
 introduced = "1.1.0"
 fixed = "1.2.0.5"
 ```

--- a/advisories/hackage/aeson/HSEC-2023-0001.md
+++ b/advisories/hackage/aeson/HSEC-2023-0001.md
@@ -1,11 +1,17 @@
 ```toml
 [advisory]
 id = "HSEC-2023-0001"
-package = "aeson"
 cwe = [328, 400]
-cvss = "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
 keywords = ["json", "dos"]
 aliases = ["CVE-2022-3433"]
+
+[[affected]]
+package = "aeson"
+cvss = "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
+
+[[affected.versions]]
+introduced = "0.4.0.0"
+fixed = "2.0.1.0"
 
 [[references]]
 type = "ARTICLE"
@@ -16,10 +22,6 @@ url = "https://frasertweedale.github.io/blog-fp/posts/2021-10-12-aeson-hash-floo
 [[references]]
 type = "DISCUSSION"
 url = "https://github.com/haskell/aeson/issues/864"
-
-[[versions]]
-introduced = "0.4.0.0"
-fixed = "2.0.1.0"
 ```
 
 # Hash flooding vulnerability in aeson

--- a/advisories/hackage/biscuit-haskell/HSEC-2023-0002.md
+++ b/advisories/hackage/biscuit-haskell/HSEC-2023-0002.md
@@ -1,11 +1,16 @@
 ```toml
 [advisory]
 id = "HSEC-2023-0002"
-package = "biscuit-haskell"
 cwe = [347]
-cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 keywords = ["crypto"]
 aliases = ["CVE-2022-31053"]
+
+[[affected]]
+package = "biscuit-haskell"
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+[[affected.versions]]
+introduced = "0.1.0.0"
+fixed = "0.2.0.0"
 
 [[references]]
 type = "REPORT"
@@ -14,9 +19,6 @@ url = "https://eprint.iacr.org/2020/1484"
 type = "ADVISORY"
 url = "https://github.com/biscuit-auth/biscuit/security/advisories/GHSA-75rw-34q6-72cr"
 
-[[versions]]
-introduced = "0.1.0.0"
-fixed = "0.2.0.0"
 ```
 
 # Improper Verification of Cryptographic Signature

--- a/advisories/hackage/xmonad-contrib/HSEC-2023-0003.md
+++ b/advisories/hackage/xmonad-contrib/HSEC-2023-0003.md
@@ -1,11 +1,16 @@
 ```toml
 [advisory]
 id = "HSEC-2023-0003"
-package = "xmonad-contrib"
 cwe = [94]
-cvss = "CVSS:2.0/AV:N/AC:L/Au:N/C:P/I:P/A:P"
 keywords = ["code", "injection"]
 aliases = ["CVE-2013-1436"]
+
+[[affected]]
+package = "xmonad-contrib"
+cvss = "CVSS:2.0/AV:N/AC:L/Au:N/C:P/I:P/A:P"
+[[affected.versions]]
+introduced = "0.5"
+fixed = "0.11.2.0"
 
 [[references]]
 type = "ADVISORY"
@@ -16,10 +21,6 @@ url = "http://www.openwall.com/lists/oss-security/2013/07/26/5"
 [[references]]
 type = "FIX"
 url = "https://github.com/xmonad/xmonad-contrib/commit/d3b2a01e3d01ac628e7a3139dd55becbfa37cf51"
-
-[[versions]]
-introduced = "0.5"
-fixed = "0.11.2"
 ```
 
 # code injection in xmonad-contrib

--- a/code/hsec-tools/src/Security/Advisories/Definition.hs
+++ b/code/hsec-tools/src/Security/Advisories/Definition.hs
@@ -3,6 +3,7 @@
 module Security.Advisories.Definition
   ( Advisory(..)
     -- * Supporting types
+  , Affected(..)
   , CWE(..)
   , Architecture(..)
   , AffectedVersionRange(..)
@@ -23,15 +24,10 @@ data Advisory = Advisory
   { advisoryId :: Text
   , advisoryModified :: ZonedTime
   , advisoryPublished :: ZonedTime
-  , advisoryPackage :: Text
   , advisoryCWEs :: [CWE]
   , advisoryKeywords :: [Keyword]
   , advisoryAliases :: [Text]
-  , advisoryCVSS :: Text
-  , advisoryVersions :: [AffectedVersionRange]
-  , advisoryArchitectures :: Maybe [Architecture]
-  , advisoryOS :: Maybe [OS]
-  , advisoryNames :: [(Text, VersionRange)]
+  , advisoryAffected :: [Affected]
   , advisoryReferences :: [Reference]
   , advisoryPandoc :: Pandoc  -- ^ Parsed document, without TOML front matter
   , advisoryHtml :: Text
@@ -39,6 +35,18 @@ data Advisory = Advisory
     -- ^ A one-line, English textual summary of the vulnerability
   , advisoryDetails :: Text
     -- ^ Details of the vulnerability (CommonMark), without TOML front matter
+  }
+  deriving stock (Show)
+
+-- | An affected package (or package component).  An 'Advisory' must
+-- mention one or more packages.
+data Affected = Affected
+  { affectedPackage :: Text
+  , affectedCVSS :: Text -- TODO refine type
+  , affectedVersions :: [AffectedVersionRange]
+  , affectedArchitectures :: Maybe [Architecture]
+  , affectedOS :: Maybe [OS]
+  , affectedDeclarations :: [(Text, VersionRange)]
   }
   deriving stock (Show)
 


### PR DESCRIPTION
A single vulnerability in a particular package may manifest itself simultaneously across one or more dependent packages. In this case, it would be good to issue a single advisory, rather than multiple. The OSV schema reflects this reality. Every OSV object has a list of affected packages, possibly with differing CVSS scores.

Modify the TOML schema to accept multiple affected packages.  There is now an array of tables called `affected`.  The `package`, `cvss`, `arch`, `os` and `declarations` fields, and the `versions` table, become members of the `affected` elements.

Fixes: https://github.com/haskell/security-advisories/issues/65


---

## hsec-tools

- [x] Previous advisories are still valid
