### PR TITLE
lib: add support for "related" field

### DIFF
--- a/code/hsec-tools/src/Security/Advisories/Definition.hs
+++ b/code/hsec-tools/src/Security/Advisories/Definition.hs
@@ -28,6 +28,7 @@ data Advisory = Advisory
   , advisoryCWEs :: [CWE]
   , advisoryKeywords :: [Keyword]
   , advisoryAliases :: [Text]
+  , advisoryRelated :: [Text]
   , advisoryAffected :: [Affected]
   , advisoryReferences :: [Reference]
   , advisoryPandoc :: Pandoc  -- ^ Parsed document, without TOML front matter

--- a/code/hsec-tools/src/Security/Advisories/Parse.hs
+++ b/code/hsec-tools/src/Security/Advisories/Parse.hs
@@ -177,6 +177,9 @@ parseAdvisoryTable oob policy table doc summary details html = runTableParser $ 
   aliases <-
     fromMaybe []
       <$> optional advisory "aliases" (isArrayOf isString)
+  related <-
+    fromMaybe []
+      <$> optional advisory "related" (isArrayOf isString)
 
   affected <- mandatory table "affected" (isArrayOf parseAffected)
   references <- mandatory table "references" (isArrayOf parseReference)
@@ -188,6 +191,7 @@ parseAdvisoryTable oob policy table doc summary details html = runTableParser $ 
     , advisoryCWEs = cats
     , advisoryKeywords = kwds
     , advisoryAliases = aliases
+    , advisoryRelated = related
     , advisoryAffected = affected
     , advisoryReferences = references
     , advisoryPandoc = doc


### PR DESCRIPTION
The "related" field in our advisory format was documented but not implemented.  Implement it.

## hsec-tools

- [ ] Previous advisories are still valid
