### PR TITLE
tools: add "related" field to OSV export

### DIFF
--- a/code/hsec-tools/src/Security/Advisories/Convert/OSV.hs
+++ b/code/hsec-tools/src/Security/Advisories/Convert/OSV.hs
@@ -20,6 +20,7 @@ convert adv =
   )
   { OSV.modelPublished = Just $ zonedTimeToUTC (advisoryPublished adv)
   , OSV.modelAliases = advisoryAliases adv
+  , OSV.modelRelated = advisoryRelated adv
   , OSV.modelSummary = Just $ advisorySummary adv
   , OSV.modelDetails = Just $ advisoryDetails adv
   , OSV.modelReferences = advisoryReferences adv


### PR DESCRIPTION
`advisoryRelated` and OSV export were recently merged (separately). As a consequence, the "related" field is not included in the conversion.  Add it now.

## hsec-tools

- [x] Previous advisories are still valid
