### PR TITLE
doc: add `references` explanation in example advisory

### DIFF
--- a/EXAMPLE_ADVISORY.md
+++ b/EXAMPLE_ADVISORY.md
@@ -30,6 +30,9 @@ fixed = "1.1"
 [[affected.versions]]
 introduced = "1.1.2"
 
+# References to articles, issues/PRs, etc.  Recognised types:
+# ADVISORY, ARTICLE, DETECTION, DISCUSSION, REPORT,
+# FIX, INTRODUCED, PACKAGE, EVIDENCE, WEB
 [[references]]
 type = "ARTICLE"
 url = "https://example.com"


### PR DESCRIPTION
Fixes: https://github.com/haskell/security-advisories/issues/53


