### PR TITLE
ci: limit osv export to haskell/security-advisories

### DIFF
--- a/.github/workflows/check-advisories.yml
+++ b/.github/workflows/check-advisories.yml
@@ -38,7 +38,7 @@ jobs:
           ! find source/advisories -name '*.md' -print0 \
             | xargs -0n1 basename | sort | uniq -c | grep -E -v '[[:space:]]*1 '
       - name: Publish OSV data
-        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+        if: ${{ github.event_name == 'push' && github.ref_name == 'main' && github.repository == 'haskell/security-advisories' }}
         env:
           GITHUB_SHA: ${{ github.sha }}
         run: |


### PR DESCRIPTION
Pushes to `main` in forks currently trigger OSV export.  This results in CI failures if the branch does not exist in the fork, and divergence from origin if it does.  Better to avoid this scenario and restrict the publish step to `haskell/security-advisories`.

