### PR TITLE
lib/advisories: add dedicated HsecId type

### DIFF
--- a/code/hsec-tools/app/Main.hs
+++ b/code/hsec-tools/app/Main.hs
@@ -8,7 +8,6 @@ import qualified Data.ByteString.Lazy as L
 import Data.Foldable (for_)
 import Data.Functor ((<&>))
 import Data.List (isPrefixOf)
-import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import Options.Applicative
 import System.Exit (die, exitFailure, exitSuccess)
@@ -45,7 +44,7 @@ commandCheck =
     go mPath advisory = do
       for_ mPath $ \path -> do
         let base = takeBaseName path
-        when ("HSEC-" `isPrefixOf` base && base /= T.unpack (advisoryId advisory)) $
+        when ("HSEC-" `isPrefixOf` base && base /= printHsecId (advisoryId advisory)) $
           die $ "Filename does not match advisory ID: " <> path
       T.putStrLn "no error"
 

--- a/code/hsec-tools/hsec-tools.cabal
+++ b/code/hsec-tools/hsec-tools.cabal
@@ -30,6 +30,7 @@ library
     exposed-modules:    Security.Advisories
                       , Security.Advisories.Definition
                       , Security.Advisories.Git
+                      , Security.Advisories.HsecId
                       , Security.Advisories.Parse
                       , Security.Advisories.Convert.OSV
                       , Security.OSV
@@ -47,6 +48,7 @@ library
                       pandoc-types >= 1.22 && < 2,
                       parsec >= 3 && < 4,
                       commonmark-pandoc >= 0.2 && < 0.3
+                      , safe >= 0.3
     hs-source-dirs:   src
     default-language: Haskell2010
     ghc-options:      -Wall

--- a/code/hsec-tools/src/Security/Advisories.hs
+++ b/code/hsec-tools/src/Security/Advisories.hs
@@ -1,8 +1,10 @@
 module Security.Advisories
   ( module Security.Advisories.Definition
+  , module Security.Advisories.HsecId
   , module Security.Advisories.Parse
   )
 where
 
 import Security.Advisories.Definition
+import Security.Advisories.HsecId
 import Security.Advisories.Parse

--- a/code/hsec-tools/src/Security/Advisories/Convert/OSV.hs
+++ b/code/hsec-tools/src/Security/Advisories/Convert/OSV.hs
@@ -15,7 +15,7 @@ import qualified Security.OSV as OSV
 convert :: Advisory -> OSV.Model Void Void Void Void
 convert adv =
   ( OSV.newModel'
-    (advisoryId adv)
+    (T.pack . printHsecId $ advisoryId adv)
     (zonedTimeToUTC $ advisoryModified adv)
   )
   { OSV.modelPublished = Just $ zonedTimeToUTC (advisoryPublished adv)

--- a/code/hsec-tools/src/Security/Advisories/Definition.hs
+++ b/code/hsec-tools/src/Security/Advisories/Definition.hs
@@ -18,10 +18,11 @@ import Distribution.Types.VersionRange (VersionRange)
 
 import Text.Pandoc.Definition (Pandoc)
 
+import Security.Advisories.HsecId
 import Security.OSV (Reference)
 
 data Advisory = Advisory
-  { advisoryId :: Text
+  { advisoryId :: HsecId
   , advisoryModified :: ZonedTime
   , advisoryPublished :: ZonedTime
   , advisoryCWEs :: [CWE]

--- a/code/hsec-tools/src/Security/Advisories/HsecId.hs
+++ b/code/hsec-tools/src/Security/Advisories/HsecId.hs
@@ -1,0 +1,77 @@
+module Security.Advisories.HsecId
+  (
+    HsecId
+  , hsecIdYear
+  , hsecIdSerial
+  , mkHsecId
+  , placeholder
+  , isPlaceholder
+  , parseHsecId
+  , printHsecId
+  , nextHsecId
+  ) where
+
+import Control.Monad (guard, join)
+
+import Safe (readMay)
+
+data HsecId = HsecId Integer Integer
+  deriving (Eq, Ord)
+
+instance Show HsecId where
+  show = printHsecId
+
+-- | Make an 'HsecId'.  Year and serial must both be positive, or
+-- else both must be zero (the 'placeholder').
+mkHsecId
+  :: Integer -- ^ Year
+  -> Integer -- ^ Serial number within year
+  -> Maybe HsecId
+mkHsecId y n
+  | y > 0 && n > 0 || y == 0 && n == 0 = Just $ HsecId y n
+  | otherwise = Nothing
+
+hsecIdYear :: HsecId -> Integer
+hsecIdYear (HsecId y _) = y
+
+hsecIdSerial :: HsecId -> Integer
+hsecIdSerial (HsecId _ n) = n
+
+-- | The placeholder ID: __HSEC-0000-0000__.
+-- See also 'isPlaceholder'.
+placeholder :: HsecId
+placeholder = HsecId 0 0
+
+-- | Test whether an ID is the 'placeholder'
+isPlaceholder :: HsecId -> Bool
+isPlaceholder = (==) placeholder
+
+-- | Parse an 'HsecId'.  The 'placeholder' is accepted.
+parseHsecId :: String -> Maybe HsecId
+parseHsecId s = case s of
+  'H':'S':'E':'C':'-':t ->
+    let
+      (y, t') = break (== '-') t
+      n = drop 1 t'
+    in do
+      guard $ length y >= 4  -- year must have at least 4 digits
+      guard $ length n >= 4  -- serial must have at least 4 digits
+      join $ mkHsecId <$> readMay y <*> readMay n
+  _ -> Nothing
+
+printHsecId :: HsecId -> String
+printHsecId (HsecId y n) = "HSEC-" <> pad (show y) <> "-" <> pad (show n)
+  where
+  pad s = replicate (4 - length s) '0' <> s
+
+-- | Given a year and an HSEC ID, return a larger HSEC ID.  This
+-- function, when given the current year and the greatest allocated
+-- HSEC ID, returns the next HSEC ID to allocate.
+--
+nextHsecId
+  :: Integer -- ^ Current year
+  -> HsecId
+  -> HsecId
+nextHsecId curYear (HsecId idYear n)
+  | curYear > idYear = HsecId curYear 1
+  | otherwise = HsecId idYear (n + 1)


### PR DESCRIPTION
Add a data type for representing HSEC IDs.  In addition to better validation when parsing advisories, this is a step towards hsec-tools features for assigning and reserving IDs.

## hsec-tools

- [ ] Previous advisories are still valid
