### PR TITLE
HSEC-2023-0004: xml-conduit entity expansion attack

### DIFF
--- a/advisories/hackage/xml-conduit/HSEC-2023-0004.md
+++ b/advisories/hackage/xml-conduit/HSEC-2023-0004.md
@@ -1,0 +1,33 @@
+```toml
+[advisory]
+id = "HSEC-2023-0004"
+cwe = [776]
+keywords = ["xml", "dos"]
+aliases = ["CVE-2021-4249", "VDB-216204"]
+
+[[affected]]
+package = "xml-conduit"
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+
+[[affected.versions]]
+introduced = "0.5.0"
+fixed = "1.9.1.0"
+
+[[references]]
+type = "FIX"
+url = "https://github.com/snoyberg/xml/pull/161"
+[[references]]
+type = "FIX"
+url = "https://github.com/snoyberg/xml/commit/4be1021791dcdee8b164d239433a2043dc0939ea"
+```
+
+# xml-conduit unbounded entity expansion
+
+A vulnerability was found in *xml-conduit*. It has been classified
+as problematic.  Affected is an unknown function of the file
+`xml-conduit/src/Text/XML/Stream/Parse.hs` of the component DOCTYPE
+Entity Expansion Handler. The manipulation leads to infinite loop.
+It is possible to launch the attack remotely. Upgrading to version
+1.9.1.0 is able to address this issue. The name of the patch is
+`4be1021791dcdee8b164d239433a2043dc0939ea`. It is recommended to
+upgrade the affected component.


### PR DESCRIPTION
Chipping away at known historical issues.

## Advisory

- [x] It's not duplicated
- [x] All fields are filled
- [x] It is validated by `hsec-tools`