### PR TITLE
HSEC-2023-0005: tls-extra does not check BasicConstraints

### DIFF
--- a/advisories/hackage/tls-extra/HSEC-2023-0005.md
+++ b/advisories/hackage/tls-extra/HSEC-2023-0005.md
@@ -1,0 +1,34 @@
+```toml
+[advisory]
+id = "HSEC-2023-0005"
+cwe = [295]
+keywords = ["x509", "pki", "mitm"]
+aliases = ["CVE-2013-0243"]
+
+[[affected]]
+package = "tls-extra"
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N"
+
+[[affected.versions]]
+introduced = "0.1.0"
+fixed = "0.4.6.1"
+
+[[references]]
+type = "DISCUSSION"
+url = "https://www.openwall.com/lists/oss-security/2013/01/30/6"
+[[references]]
+type = "REPORT"
+url = "https://github.com/haskell-tls/hs-tls/issues/29"
+[[references]]
+type = "FIX"
+url = "https://github.com/haskell-tls/hs-tls/commit/15885c0649ceabd2f4d2913df8ac6dc63d6b3b37"
+```
+
+# tls-extra: certificate validation does not check Basic Constraints
+
+*tls-extra* does not check the Basic Constraints extension of a
+certificate in certificate chain processing.  Any certificate is
+treated as a CA certificate.  As a consequence, anyone who has a
+valid certificate can use it to sign another one (with an arbitrary
+subject DN/domain name embedded into it) and have it accepted by
+*tls*.  This allows MITM attacks on TLS connections.


### PR DESCRIPTION
Another historical advisory.

## hsec-tools

- [ ] Previous advisories are still valid
