### PR TITLE
fix(tools): override dependencies at package level to improve caching in nix

### DIFF
--- a/code/hsec-tools/flake.nix
+++ b/code/hsec-tools/flake.nix
@@ -17,9 +17,7 @@
 
           haskellPackages = pkgs.haskell.packages.ghc925.override
             {
-              overrides = hself: hsuper: {
-                Cabal-syntax = hsuper.Cabal-syntax_3_8_1_0;
-              };
+              overrides = hself: hsuper: { };
             };
         in
         rec
@@ -27,6 +25,7 @@
           packages.hsec-tools =
             haskellPackages.callCabal2nix "hsec-tools" ./. {
               # Dependency overrides go here
+              Cabal-syntax = haskellPackages.Cabal-syntax_3_8_1_0;
             };
 
           defaultPackage = packages.hsec-tools;


### PR DESCRIPTION
See https://github.com/haskell/security-advisories/pull/94#issuecomment-1642304387

---

## hsec-tools

- [x] Previous advisories are still valid
