### PR TITLE
tools: improve nix caching

### DIFF
--- a/code/hsec-tools/flake.lock
+++ b/code/hsec-tools/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1687171271,
-        "narHash": "sha256-BJlq+ozK2B1sJDQXS3tzJM5a+oVZmi1q0FlBK/Xqv7M=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "abfb11bd1aec8ced1c9bb9adfe68018230f4fb3c",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687502512,
-        "narHash": "sha256-dBL/01TayOSZYxtY4cMXuNCBk8UMLoqRZA+94xiFpJA=",
+        "lastModified": 1689679375,
+        "narHash": "sha256-LHUC52WvyVDi9PwyL1QCpaxYWBqp4ir4iL6zgOkmcb8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3ae20aa58a6c0d1ca95c9b11f59a2d12eebc511f",
+        "rev": "684c17c429c42515bafb3ad775d2a710947f3d67",
         "type": "github"
       },
       "original": {

--- a/code/hsec-tools/flake.nix
+++ b/code/hsec-tools/flake.nix
@@ -19,6 +19,7 @@
             root = ./.;
             withHoogle = false;
             overrides = self: super: with pkgs.haskell.lib; {
+              Cabal-syntax = super.Cabal-syntax_3_8_1_0;
             };
             modifier = drv:
               pkgs.haskell.lib.addBuildTools drv (with pkgs.haskellPackages;
@@ -33,7 +34,7 @@
       in
       {
         # Used by `nix build` & `nix run` (prod exe)
-        defaultPackage = project true;
+        defaultPackage = project false;
 
         # Used by `nix develop` (dev shell)
         devShell = project true;

--- a/code/hsec-tools/flake.nix
+++ b/code/hsec-tools/flake.nix
@@ -7,40 +7,35 @@
   };
 
   outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem
-      (system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-
-          jailbreakUnbreak = pkg:
-            pkgs.haskell.lib.doJailbreak (pkgs.haskell.lib.dontCheck (pkgs.haskell.lib.unmarkBroken pkg));
-
-          haskellPackages = pkgs.haskell.packages.ghc925.override
-            {
-              overrides = hself: hsuper: {
-                Cabal-syntax = hsuper.Cabal-syntax_3_8_1_0;
-              };
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ ];
+        pkgs =
+          import nixpkgs { inherit system overlays; config.allowBroken = true; };
+        project = returnShellEnv:
+          pkgs.haskellPackages.developPackage {
+            inherit returnShellEnv;
+            name = "hsec-tools";
+            root = ./.;
+            withHoogle = false;
+            overrides = self: super: with pkgs.haskell.lib; {
             };
-        in
-        rec
-        {
-          packages.hsec-tools =
-            haskellPackages.callCabal2nix "hsec-tools" ./. {
-              # Dependency overrides go here
-            };
-
-          defaultPackage = packages.hsec-tools;
-
-          devShell =
-            pkgs.mkShell {
-              buildInputs = with haskellPackages; [
-                haskell-language-server
-                ghcid
+            modifier = drv:
+              pkgs.haskell.lib.addBuildTools drv (with pkgs.haskellPackages;
+              [
+                cabal-fmt
                 cabal-install
-              ];
-              inputsFrom = [
-                self.defaultPackage.${system}.env
-              ];
-            };
+                ghcid
+                haskell-language-server
+                pkgs.nixpkgs-fmt
+              ]);
+          };
+      in
+      {
+        # Used by `nix build` & `nix run` (prod exe)
+        defaultPackage = project true;
+
+        # Used by `nix develop` (dev shell)
+        devShell = project true;
         });
 }

--- a/code/hsec-tools/flake.nix
+++ b/code/hsec-tools/flake.nix
@@ -38,5 +38,5 @@
 
         # Used by `nix develop` (dev shell)
         devShell = project true;
-        });
+      });
 }

--- a/code/hsec-tools/shell.nix
+++ b/code/hsec-tools/shell.nix
@@ -1,0 +1,3 @@
+(import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
+  src = ./.;
+}).shellNix.default


### PR DESCRIPTION
See #96 -- introduce `developPackage`, compat layer for `shell.nix` and some formatting. This fixes nix build/cache issues.
---

## hsec-tools

- [x] Previous advisories are still valid
