### PR TITLE
tools/index: ignore symlinks to avoid duplicate entries

### DIFF
--- a/.github/workflows/check-advisories.yml
+++ b/.github/workflows/check-advisories.yml
@@ -35,7 +35,7 @@ jobs:
           exit $RESULT
       - name: Run advisory uniqueness checks
         run: |
-          ! find source/advisories -name '*.md' -print0 \
+          ! find source/advisories -type f -name '*.md' -print0 \
             | xargs -0n1 basename | sort | uniq -c | grep -E -v '[[:space:]]*1 '
       - name: Publish OSV data
         if: ${{ github.event_name == 'push' && github.ref_name == 'main' && github.repository == 'haskell/security-advisories' }}


### PR DESCRIPTION
Advisories with multiple affected packages will be defined as a single file in the "lowest level" package directory, with inbound symbolic links of the same name in the other package directories.

Update the generate-index command to ignore symbolic links.  This prevents duplicate entries appearing in the lists/tables.

## hsec-tools

- [ ] Previous advisories are still valid
