### PR TITLE
ci: properly handle multiple changed advisories

### DIFF
--- a/.github/workflows/check-advisories-standalone.yml
+++ b/.github/workflows/check-advisories-standalone.yml
@@ -20,14 +20,24 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      changed_files: ${{ steps.process-changed-files.outputs.out }}
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v5.3.0
         with:
           concurrent_skipping: "never"
           skip_after_successful_duplicate: "true"
-          paths: '["advisories/**"]'
+          paths: '["advisories/**", "EXAMPLE_ADVISORY.md"]'
           do_not_skip: '["push", "workflow_dispatch", "schedule"]'
+      - id: process-changed-files
+        name: Extract matched files list
+        env:
+          PATHS_RESULT: ${{ steps.skip_check.outputs.paths_result }}
+        run: |
+          echo -n 'out=' >> "$GITHUB_OUTPUT"
+          # See https://github.com/fkirc/skip-duplicate-actions#paths_result
+          printenv PATHS_RESULT \
+            | jq --compact-output .global.matched_files >> "$GITHUB_OUTPUT"
   code_hash:
     name: Compute code directory hash
     runs-on: ubuntu-22.04
@@ -40,30 +50,12 @@ jobs:
         run: |
           code_hash=$(git rev-parse HEAD:code)
           echo "code-hash=$code_hash" >> "$GITHUB_OUTPUT"
-  changed_files:
-    name: Debug
-    needs: [tools_changed, advisories_changed, code_hash]
-    if: ${{ needs.tools_changed.outputs.should_skip == 'true' && needs.advisories_changed.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-22.04
-    permissions:
-      pull-requests: read
-    outputs:
-      advisories: ${{ steps.changed-files.outputs.all_changed_files }}
-    steps:
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v37
-        with:
-          json: "true"
-
-      - name: List all changed files
-        run: echo "${{ steps.changed-files.outputs.all_changed_files }}"
   check_advisories:
     name: Invoke check-advisories workflow
-    needs: [tools_changed, advisories_changed, code_hash, changed_files]
+    needs: [tools_changed, advisories_changed, code_hash]
     if: ${{ needs.tools_changed.outputs.should_skip == 'true' && needs.advisories_changed.outputs.should_skip != 'true' }}
     uses: ./.github/workflows/check-advisories.yml
     with:
       fetch-key: hsec-tools-${{ needs.code_hash.outputs.code_hash }}
       is-artifact: false
-      changed-advisories: ${{ needs.changed_files.outputs.advisories }}
+      changed-advisories: ${{ needs.advisories_changed.outputs.changed_files }}

--- a/.github/workflows/check-advisories.yml
+++ b/.github/workflows/check-advisories.yml
@@ -37,11 +37,11 @@ jobs:
           path: ~/.local/dockerImages
           fail-on-cache-miss: true
       - run: docker load -i ~/.local/dockerImages/hsec-tools
-      - name: 'Setup jq'
-        uses: dcarbone/install-jq-action@v1.0.1
       - name: Run advisory syntax checks
+        env:
+          CHANGED_ADVISORIES_JSON: ${{ inputs.changed-advisories }}
         run: |
-          CHANGED_ADVISORIES=( $(echo "${{ inputs.changed-advisories }}" | jq -r '.[]') )
+          CHANGED_ADVISORIES=( $(printenv CHANGED_ADVISORIES_JSON | jq -r '.[]') )
           cd source
           RESULT=0
           # Remove the begining of the README to extract the example.
@@ -49,7 +49,7 @@ jobs:
           while read FILE ; do
             echo -n "$FILE: "
             docker run --rm -v $PWD:/advisories haskell/hsec-tools:latest /bin/hsec-tools check "advisories/$FILE" || RESULT=1
-          done < <([ ${#CHANGED_ADVISORIES[@]} -gt 0 ] && echo $CHANGED_ADVISORIES || find advisories EXAMPLE_README.md EXAMPLE_ADVISORY.md -type f -name "*.md")
+          done < <([ ${#CHANGED_ADVISORIES[@]} -gt 0 ] && printf "%s\n" "${CHANGED_ADVISORIES[@]}" || find advisories EXAMPLE_README.md EXAMPLE_ADVISORY.md -type f -name "*.md")
           exit $RESULT
       - name: Run advisory uniqueness checks
         run: |


### PR DESCRIPTION
The updated CI does not properly interpret the list of changed files so that only modified advisories get checked (when *only* advisories changed).

- The "changed files" list could include non-advisories (e.g.  CI workflow YAML files).  Update the `advisories_changed` job to output the filtered file list (as JSON).

- Remove the `changed_files` job.  It is not needed.  We output the matched files from the `advisories_changed` job.

- There were some `bash` command parsing errors when including the JSON in the command arguments.  Propagate it in environment variables instead.

- Finally, `$CHANGED_ADVISORIES` outputs only the first element of the array.  Use `printf` to print the array, one file per line.


---

## Advisory

- [ ] It's not duplicated
- [ ] All fields are filled
- [ ] It is validated by `hsec-tools`

## hsec-tools

- [ ] Previous advisories are still valid
