### PR TITLE
add keyword to indicate "historical" advisories

### DIFF
--- a/advisories/hackage/aeson/HSEC-2023-0001.md
+++ b/advisories/hackage/aeson/HSEC-2023-0001.md
@@ -2,7 +2,7 @@
 [advisory]
 id = "HSEC-2023-0001"
 cwe = [328, 400]
-keywords = ["json", "dos"]
+keywords = ["json", "dos", "historical"]
 aliases = ["CVE-2022-3433"]
 
 [[affected]]

--- a/advisories/hackage/biscuit-haskell/HSEC-2023-0002.md
+++ b/advisories/hackage/biscuit-haskell/HSEC-2023-0002.md
@@ -2,7 +2,7 @@
 [advisory]
 id = "HSEC-2023-0002"
 cwe = [347]
-keywords = ["crypto"]
+keywords = ["crypto", "historical"]
 aliases = ["CVE-2022-31053"]
 related = ["GHSA-75rw-34q6-72cr"]
 

--- a/advisories/hackage/hledger-web/HSEC-2023-0008.md
+++ b/advisories/hackage/hledger-web/HSEC-2023-0008.md
@@ -2,7 +2,7 @@
 [advisory]
 id = "HSEC-2023-0008"
 cwe = [87]
-keywords = ["web", "xss"]
+keywords = ["web", "xss", "historical"]
 aliases = ["CVE-2021-46888"]
 
 [[affected]]

--- a/advisories/hackage/tls-extra/HSEC-2023-0005.md
+++ b/advisories/hackage/tls-extra/HSEC-2023-0005.md
@@ -2,7 +2,7 @@
 [advisory]
 id = "HSEC-2023-0005"
 cwe = [295]
-keywords = ["x509", "pki", "mitm"]
+keywords = ["x509", "pki", "mitm", "historical"]
 aliases = ["CVE-2013-0243"]
 
 [[affected]]

--- a/advisories/hackage/x509-validation/HSEC-2023-0006.md
+++ b/advisories/hackage/x509-validation/HSEC-2023-0006.md
@@ -2,7 +2,7 @@
 [advisory]
 id = "HSEC-2023-0006"
 cwe = [295]
-keywords = ["x509", "pki"]
+keywords = ["x509", "pki", "historical"]
 
 [[affected]]
 package = "x509-validation"

--- a/advisories/hackage/xml-conduit/HSEC-2023-0004.md
+++ b/advisories/hackage/xml-conduit/HSEC-2023-0004.md
@@ -2,7 +2,7 @@
 [advisory]
 id = "HSEC-2023-0004"
 cwe = [776]
-keywords = ["xml", "dos"]
+keywords = ["xml", "dos", "historical"]
 aliases = ["CVE-2021-4249", "VDB-216204"]
 
 [[affected]]

--- a/advisories/hackage/xmonad-contrib/HSEC-2023-0003.md
+++ b/advisories/hackage/xmonad-contrib/HSEC-2023-0003.md
@@ -2,7 +2,7 @@
 [advisory]
 id = "HSEC-2023-0003"
 cwe = [94]
-keywords = ["code", "injection"]
+keywords = ["code", "injection", "historical"]
 aliases = ["CVE-2013-1436"]
 
 [[affected]]
@@ -10,7 +10,7 @@ package = "xmonad-contrib"
 cvss = "CVSS:2.0/AV:N/AC:L/Au:N/C:P/I:P/A:P"
 [[affected.versions]]
 introduced = "0.5"
-fixed = "0.11.2.0"
+fixed = "0.11.2"
 
 [[references]]
 type = "ADVISORY"
@@ -23,6 +23,9 @@ type = "FIX"
 url = "https://github.com/xmonad/xmonad-contrib/commit/d3b2a01e3d01ac628e7a3139dd55becbfa37cf51"
 ```
 
-# code injection in xmonad-contrib
+# code injection in *xmonad-contrib*
 
-The _XMonad.Hooks.DynamicLog_ module in _xmonad-contrib_ before 0.11.2 allows remote attackers to execute arbitrary commands via a web page title, which activates the commands when the user clicks on the xmobar window title, as demonstrated using an action tag.
+The `XMonad.Hooks.DynamicLog` module in _xmonad-contrib_ before
+**0.11.2** allows remote attackers to execute arbitrary commands via a
+web page title, which activates the commands when the user clicks on
+the xmobar window title, as demonstrated using an action tag.


### PR DESCRIPTION
Historical advisories report issues that were disclosed and fixed before the HSEC advisory database existed.  For accurate statistics about contemporary security issues in the Haskell ecosystem, add the "historical" keyword to such advisories.  We can use it to filter advisories.

---

## Advisory

- [ ] It's not duplicated
- [ ] All fields are filled
- [ ] It is validated by `hsec-tools`
