### PR TITLE
fix(git): adapt gitignore after flake move

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *~
 dist-newstyle/
+result
+.direnv
+.env


### PR DESCRIPTION
---

## hsec-tools

- [x] Previous advisories are still valid
