### PR TITLE
hsec-tools: add reserve command

### DIFF
--- a/.github/workflows/check-advisories.yml
+++ b/.github/workflows/check-advisories.yml
@@ -47,6 +47,7 @@ jobs:
           # Remove the begining of the README to extract the example.
           (echo '```toml'; sed -e '1,/```toml/d' README.md) > EXAMPLE_README.md
           while read FILE ; do
+            [ "$(dirname "$FILE")" != advisories/reserved ] || continue
             echo -n "$FILE: "
             docker run --rm -v $PWD:/repo --workdir /repo haskell/hsec-tools:latest /bin/hsec-tools check "$FILE" || RESULT=1
           done < <([ ${#CHANGED_ADVISORIES[@]} -gt 0 ] && printf "%s\n" "${CHANGED_ADVISORIES[@]}" || find advisories EXAMPLE_README.md EXAMPLE_ADVISORY.md -type f -name "*.md")

--- a/code/hsec-tools/app/Command/Reserve.hs
+++ b/code/hsec-tools/app/Command/Reserve.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Command.Reserve where
+
+import Control.Monad (unless)
+import Data.Maybe (fromMaybe)
+import System.Exit (die)
+import System.FilePath ((</>), (<.>))
+
+import Security.Advisories.Git (getRepoRoot)
+import Security.Advisories.HsecId
+  ( placeholder
+  , printHsecId
+  , getNextHsecId
+  )
+import Security.Advisories.Filesystem
+  ( dirNameAdvisories
+  , dirNameReserved
+  , isSecurityAdvisoriesRepo
+  , getGreatestId
+  )
+
+-- | How to choose IDs when creating advisories or
+-- reservations.
+data IdMode
+  = IdModePlaceholder
+  -- ^ Create a placeholder ID (e.g. HSEC-0000-0000).  Real IDs
+  -- will be assigned later.
+  | IdModeAuto
+  -- ^ Use the next available ID.  This option is more likely to
+  -- result in conflicts when submitting advisories or reservations.
+
+runReserveCommand :: Maybe FilePath -> IdMode -> IO ()
+runReserveCommand mPath idMode = do
+  let
+    path = fromMaybe "." mPath
+  repoPath <- getRepoRoot path >>= \case
+    Left _ -> die "Not a git repo"
+    Right a -> pure a
+  isRepo <- isSecurityAdvisoriesRepo repoPath
+  unless isRepo $
+    die "Not a security-advisories repo"
+
+  hsid <- case idMode of
+    IdModePlaceholder -> pure placeholder
+    IdModeAuto -> do
+      curMax <- getGreatestId repoPath
+      getNextHsecId curMax
+
+  let
+    advisoriesPath = repoPath </> dirNameAdvisories
+    fileName = printHsecId hsid <.> "md"
+    filePath = advisoriesPath </> dirNameReserved </> fileName
+  writeFile filePath ""  -- write empty file

--- a/code/hsec-tools/app/Main.hs
+++ b/code/hsec-tools/app/Main.hs
@@ -57,6 +57,12 @@ commandReserve =
         , ("auto",        Command.Reserve.IdModeAuto)
         ]
         ( long "id-mode" <> help "How to assign IDs" )
+  <*> flag
+        Command.Reserve.DoNotCommit -- default value
+        Command.Reserve.Commit      -- active value
+        ( long "commit"
+        <> help "Commit the reservation file"
+        )
   <**> helper
 
 commandCheck :: Parser (IO ())

--- a/code/hsec-tools/hsec-tools.cabal
+++ b/code/hsec-tools/hsec-tools.cabal
@@ -68,6 +68,8 @@ library
 
 executable hsec-tools
     main-is:          Main.hs
+    other-modules:
+      Command.Reserve
 
     -- Modules included in this executable, other than Main.
     -- other-modules:

--- a/code/hsec-tools/hsec-tools.cabal
+++ b/code/hsec-tools/hsec-tools.cabal
@@ -30,6 +30,7 @@ tested-with:
 library
     exposed-modules:    Security.Advisories
                       , Security.Advisories.Definition
+                      , Security.Advisories.Filesystem
                       , Security.Advisories.Git
                       , Security.Advisories.HsecId
                       , Security.Advisories.Parse
@@ -51,6 +52,7 @@ library
                       toml-reader ^>= 0.1 || ^>= 0.2,
                       aeson >= 2.0.1.0 && < 3,
                       pandoc-types >= 1.22 && < 2,
+                      pathwalk >= 0.3,
                       parsec >= 3 && < 4,
                       commonmark-pandoc >= 0.2 && < 0.3
                       , safe >= 0.3

--- a/code/hsec-tools/src/Security/Advisories/Filesystem.hs
+++ b/code/hsec-tools/src/Security/Advisories/Filesystem.hs
@@ -1,0 +1,133 @@
+{-|
+
+Helpers for the /security-advisories/ file system.
+
+Top-level functions that take a @FilePath@ expect the path to the
+top-level directory of the /security-advisories/ repository (i.e.
+it must have the @advisories/@ subdirectory).
+
+-}
+module Security.Advisories.Filesystem
+  (
+    dirNameAdvisories
+  , dirNameReserved
+  , isSecurityAdvisoriesRepo
+  , getReservedIds
+  , getAdvisoryIds
+  , getAllocatedIds
+  , greatestId
+  , getGreatestId
+  , forReserved
+  , forAdvisory
+  ) where
+
+import Control.Applicative (liftA2)
+import Data.Foldable (fold)
+import Data.Semigroup (Max(Max, getMax))
+import Data.Traversable (for)
+
+import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.Writer.Strict (execWriterT, tell)
+import System.FilePath ((</>), takeBaseName)
+import System.Directory (doesDirectoryExist)
+import System.Directory.PathWalk
+
+import Security.Advisories.HsecId (HsecId, parseHsecId, placeholder)
+
+
+dirNameAdvisories :: FilePath
+dirNameAdvisories = "advisories"
+
+dirNameReserved :: FilePath
+dirNameReserved = "reserved"
+
+-- | Check whether the directory appears to be the root of a
+-- /security-advisories/ filesystem.  Only checks that the
+-- @advisories@ subdirectory exists.
+--
+isSecurityAdvisoriesRepo :: FilePath -> IO Bool
+isSecurityAdvisoriesRepo path =
+  doesDirectoryExist (path </> dirNameAdvisories)
+
+
+-- | Get a list of reserved HSEC IDs.  The order is unspecified.
+--
+getReservedIds :: FilePath -> IO [HsecId]
+getReservedIds root =
+  forReserved root (\_ hsid -> pure [hsid])
+
+-- | Get a list of used IDs (does not include reserved IDs)
+-- There may be duplicates and the order is unspecified.
+--
+getAdvisoryIds :: FilePath -> IO [HsecId]
+getAdvisoryIds root =
+  forAdvisory root (\_ hsid -> pure [hsid])
+
+-- | Get all allocated IDs, including reserved IDs.
+-- There may be duplicates and the order is unspecified.
+--
+getAllocatedIds :: FilePath -> IO [HsecId]
+getAllocatedIds root =
+  liftA2 (<>)
+    (getAdvisoryIds root)
+    (getReservedIds root)
+
+-- | Return the greatest ID in a collection of IDs.  If the
+-- collection is empty, return the 'placeholder'.
+--
+greatestId :: (Foldable t) => t HsecId -> HsecId
+greatestId = getMax . foldr ((<>) . Max) (Max placeholder)
+
+-- | Return the greatest ID in the database, including reserved IDs.
+-- If there are IDs in the database, returns the 'placeholder'.
+--
+getGreatestId :: FilePath -> IO HsecId
+getGreatestId = fmap greatestId . getAllocatedIds
+
+
+-- | Invoke a callback for each HSEC ID in the reserved
+-- directory.  The results are combined monoidally.
+--
+forReserved
+  :: (MonadIO m, Monoid r)
+  => FilePath -> (FilePath -> HsecId -> m r) -> m r
+forReserved root =
+  _forFiles (root </> dirNameAdvisories </> dirNameReserved)
+
+-- | Invoke a callback for each HSEC ID under each of the advisory
+-- subdirectories, excluding the @reserved@ directory.  The results
+-- are combined monoidally.
+--
+-- The same ID could appear multiple times.  In particular, the callback
+-- is invoked for symbolic links as well as regular files.
+--
+forAdvisory
+  :: (MonadIO m, Monoid r)
+  => FilePath -> (FilePath -> HsecId -> m r) -> m r
+forAdvisory root go = do
+  let dir = root </> dirNameAdvisories
+  subdirs <- filter (/= dirNameReserved) <$> _getSubdirs dir
+  fmap fold $ for subdirs $ \subdir -> _forFiles (dir </> subdir) go
+
+-- | Get names (not paths) of subdirectories of the given directory
+-- (one level).  There's no monoidal, interruptible variant of
+-- @pathWalk@ so we use @WriterT@ to smuggle the result out.
+--
+_getSubdirs :: (MonadIO m) => FilePath -> m [FilePath]
+_getSubdirs root =
+  execWriterT $
+    pathWalkInterruptible root $ \_ subdirs _ -> do
+      tell subdirs
+      pure Stop
+
+_forFiles
+  :: (MonadIO m, Monoid r)
+  => FilePath  -- ^ (sub)directory name
+  -> (FilePath -> HsecId -> m r)
+  -> m r
+_forFiles root go =
+  pathWalkAccumulate root $ \_ _ files ->
+    fmap fold $ for files $ \file ->
+      case parseHsecId (takeBaseName file) of
+        Nothing -> pure mempty
+        Just hsid -> go (root </> file) hsid

--- a/code/hsec-tools/src/Security/Advisories/HsecId.hs
+++ b/code/hsec-tools/src/Security/Advisories/HsecId.hs
@@ -9,9 +9,13 @@ module Security.Advisories.HsecId
   , parseHsecId
   , printHsecId
   , nextHsecId
+  , getNextHsecId
   ) where
 
 import Control.Monad (guard, join)
+
+import Data.Time (getCurrentTime, utctDay)
+import Data.Time.Calendar.OrdinalDate (toOrdinalDate)
 
 import Safe (readMay)
 
@@ -75,3 +79,15 @@ nextHsecId
 nextHsecId curYear (HsecId idYear n)
   | curYear > idYear = HsecId curYear 1
   | otherwise = HsecId idYear (n + 1)
+
+-- | Get the current time, and return an HSEC ID greater than the
+-- given HSEC ID.  The year of the returned HSEC ID is the current
+-- year.
+--
+getNextHsecId
+  :: HsecId
+  -> IO HsecId
+getNextHsecId oldId = do
+  t <- getCurrentTime
+  let (year, _dayOfYear) = toOrdinalDate (utctDay t)
+  pure $ nextHsecId year oldId


### PR DESCRIPTION
***note*** this PR consists of several commits.  I recommend to review
them separately, in chronological order, as they step by step introduce
the supporting library code and then the feature.

This PR adds the `reserve-id` command, which requests or assigns an HSEC
ID reservation.  It can also commit the change, ready for the
contributor to push and create a pull request.

Reservations are empty files under advisories/reserved.

CI enforces uniqueness.  When reservations get replaced with a full
advisory the reservation file must be removed in the same commit.

Reservation files SHOULD be empty, but nothing enforces that (yet).

Fixes: https://github.com/haskell/security-advisories/issues/110


---

## hsec-tools

- [ ] Previous advisories are still valid