### PR TITLE
Add GHSA-xj5q-fv23-575g for pandoc

### DIFF
--- a/advisories/hackage/pandoc/HSEC-0000-0000.md
+++ b/advisories/hackage/pandoc/HSEC-0000-0000.md
@@ -1,0 +1,29 @@
+```toml
+[advisory]
+id = "HSEC-0000-0000"
+date = 2021-01-31
+keywords = ["file write"]
+aliases = ["CVE-2023-35936", "GHSA-xj5q-fv23-575g"]
+cwe = [20]
+
+[[references]]
+type = "REPORT"
+url = "https://github.com/jgm/pandoc/security/advisories/GHSA-xj5q-fv23-575g"
+
+[[affected]]
+package = "pandoc"
+cvss = "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:C/C:N/I:H/A:L"
+
+[[affected.versions]]
+introduced = "1.13"
+fixed = "3.1.4"
+
+```
+# Arbitrary file write is possible when using PDF output or --extract-media with untrusted input
+
+Pandoc is susceptible to an arbitrary file write vulnerability, which can be triggered by providing a specially crafted image element in the input when generating files using the --extract-media option or outputting to PDF format. This vulnerability allows an attacker to create or overwrite arbitrary files on the system (depending on the privileges of the process running pandoc).
+
+This vulnerability only affects systems that (a) pass untrusted user input to pandoc and (b) allow pandoc to be used to produce a PDF or with the --extract-media option.
+
+The vulnerability is patched in pandoc 3.1.4.
+

--- a/advisories/hackage/pandoc/HSEC-2023-0014.md
+++ b/advisories/hackage/pandoc/HSEC-2023-0014.md
@@ -1,7 +1,6 @@
 ```toml
 [advisory]
-id = "HSEC-0000-0000"
-date = 2021-01-31
+id = "HSEC-2023-0014"
 keywords = ["file write"]
 aliases = ["CVE-2023-35936", "GHSA-xj5q-fv23-575g"]
 cwe = [20]
@@ -26,4 +25,3 @@ Pandoc is susceptible to an arbitrary file write vulnerability, which can be tri
 This vulnerability only affects systems that (a) pass untrusted user input to pandoc and (b) allow pandoc to be used to produce a PDF or with the --extract-media option.
 
 The vulnerability is patched in pandoc 3.1.4.
-


### PR DESCRIPTION
Hey all, was going through some advisories I've been tracking and noticed you were missing one that I had. Hope I followed the format correctly for adding an advisory

Source report:
https://github.com/jgm/pandoc/security/advisories/GHSA-xj5q-fv23-575g

---

## Advisory

- [x] It's not duplicated
- [x] All fields are filled
- [ ] It is validated by `hsec-tools`

## hsec-tools

- [ ] Previous advisories are still valid
