### PR TITLE
HSEC-2023-0015: better summary

### DIFF
--- a/advisories/hackage/cabal-install/HSEC-2023-0015.md
+++ b/advisories/hackage/cabal-install/HSEC-2023-0015.md
@@ -19,7 +19,7 @@ type = "FIX"
 url = "https://github.com/haskell/cabal/commit/dcfdc9cffd74cade4e8cf3df37c5993413ffd30f"
 ```
 
-# Summary
+# cabal-install uses expired key policies
 
 A problem was recently discovered in `cabal-install`'s
 implementation of the Hackage Security protocol that would allow an
@@ -31,7 +31,7 @@ only a theoretical attack - no keys have been revoked. Release
 contacted distributors of older versions (such as Linux
 distributions) with a patch that they can apply.
 
-# Background
+## Background
 
 Hackage Security is an implementation of [The Update Framework][],
 which is a design for a package repository that allows untrusted
@@ -79,7 +79,7 @@ malicious or obsolete package index.
 [key policy file]: https://hackage.haskell.org/root.json
 [The Update Framework]: https://theupdateframework.io/
 
-# The Issue
+## The Issue
 
 A bug in `cabal-install` caused it to skip the verification of the
 key policy file's expiration timestamp. This means that users of


### PR DESCRIPTION
The markdown parser extracts the summary text "Summary", which lacks information.  Update the headings so that a better summary is produced.

---

## Advisory

- [ ] It's not duplicated
- [ ] All fields are filled
- [ ] It is validated by `hsec-tools`