### PR TITLE
osv: fix ToJSON encoding of Severity object

### DIFF
--- a/code/hsec-tools/src/Security/OSV.hs
+++ b/code/hsec-tools/src/Security/OSV.hs
@@ -171,10 +171,10 @@ instance FromJSON Severity where
           $ typeMismatch "severity" (Object o)
 
 instance ToJSON Severity where
-  toJSON (Severity cvss) = object ["type" .= CVSS.cvssVectorString cvss, "score" .= score]
+  toJSON (Severity cvss) = object ["score" .= CVSS.cvssVectorString cvss, "type" .= typ]
     where
-      score :: Text
-      score = case CVSS.cvssVersion cvss of
+      typ :: Text
+      typ = case CVSS.cvssVersion cvss of
         CVSS.CVSS31 -> "CVSS_V3"
         CVSS.CVSS30 -> "CVSS_V3"
         CVSS.CVSS20 -> "CVSS_V2"


### PR DESCRIPTION
"type" and "score" fields were mixed up.  Put them straight.

Fixes: https://github.com/haskell/security-advisories/issues/135

---

## hsec-tools

- [ ] Previous advisories are still valid
