### PR TITLE
fix: generate .nojekyll with index to activate GitHub pages

### DIFF
--- a/code/hsec-tools/src/Security/Advisories/Generate/HTML.hs
+++ b/code/hsec-tools/src/Security/Advisories/Generate/HTML.hs
@@ -58,6 +58,8 @@ renderAdvisoriesIndex src dst = do
         div_ [class_ "pure-u-1"] $
           toHtmlRaw (Advisories.advisoryHtml advisory)
 
+  writeFile (dst </> ".nojekyll") ""
+
 -- * Rendering types
 
 data AdvisoryR = AdvisoryR


### PR DESCRIPTION
---

## hsec-tools

- [x] Previous advisories are still valid
