### PR TITLE
Support toml-parser-2.0.0.0

### DIFF
--- a/code/hsec-tools/hsec-tools.cabal
+++ b/code/hsec-tools/hsec-tools.cabal
@@ -61,7 +61,7 @@ library
     , safe                  >=0.3
     , text                  >=1.2      && <3
     , time                  >=1.9      && <1.14
-    , toml-parser           ^>=1.3.0.0
+    , toml-parser           ^>=2.0.0.0
     , validation-selective  >=0.1      && <1
 
   hs-source-dirs:   src

--- a/code/hsec-tools/test/golden/MISSING_AFFECTED.md.golden
+++ b/code/hsec-tools/test/golden/MISSING_AFFECTED.md.golden
@@ -1,10 +1,17 @@
 Left
     ( AdvisoryError
         [ MatchMessage
-            { matchPath = []
+            { matchAnn = Just
+                ( Position
+                    { posIndex = 0
+                    , posLine = 1
+                    , posColumn = 1
+                    }
+                )
+            , matchPath = []
             , matchMessage = "missing key: affected"
             }
-        ] "missing key: affected in top
+        ] "1:1: missing key: affected in <top-level>
       "
     )
 

--- a/flake.lock
+++ b/flake.lock
@@ -59,17 +59,17 @@
     "toml-parser": {
       "flake": false,
       "locked": {
-        "lastModified": 1689547204,
-        "narHash": "sha256-b953MDru/A80AQiejwiBojJlab0Kr9fGODtVUpOIQMc=",
+        "lastModified": 1708792062,
+        "narHash": "sha256-RiRBBnDriQi9jH76JVr72ygYWtGF963iv/XoPBuMA3U=",
         "owner": "glguy",
         "repo": "toml-parser",
-        "rev": "eb7222d9d71aa00d0a37f85ff4cdef89d1ba743d",
+        "rev": "4bcf07dc403a0882e9ce5a423473306cf1863f2f",
         "type": "github"
       },
       "original": {
         "owner": "glguy",
+        "ref": "toml-parser-2.0.0.0",
         "repo": "toml-parser",
-        "rev": "eb7222d9d71aa00d0a37f85ff4cdef89d1ba743d",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     toml-parser = {
-      url = "github:glguy/toml-parser/eb7222d9d71aa00d0a37f85ff4cdef89d1ba743d"; # v1.3.0.0
+      url = "github:glguy/toml-parser/toml-parser-2.0.0.0";
       flake = false;
     };
   };


### PR DESCRIPTION
This new version provides native Text support and mapping schema errors back to source positions.


---

## hsec-tools

- [x] Previous advisories are still valid
