### PR TITLE
HSEC-2024-0001: host header rXSS in keter

### DIFF
--- a/advisories/hackage/keter/HSEC-2024-0001.md
+++ b/advisories/hackage/keter/HSEC-2024-0001.md
@@ -1,0 +1,30 @@
+```toml
+[advisory]
+id = "HSEC-2024-0001"
+cwe = [79]
+keywords = ["http", "xss", "rxss", "historic"]
+
+[[references]]
+type = "FIX"
+url = "https://github.com/snoyberg/keter/pull/246"
+
+[[affected]]
+package = "keter"
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:L/I:L/A:N"
+declarations."Keter.Proxy.toResponse" = ">= 0.3.4 && < 1.0.1"
+declarations."Keter.Proxy.unknownHostResponse" = ">= 1.0.1 && < 1.8.4"
+
+[[affected.versions]]
+introduced = "0.3.4"
+fixed = "1.8.4"
+```
+
+# Reflected XSS vulnerability in keter
+
+Keter is an app-server/reverse-proxy often used with webapps build on Yesod web-framework.
+
+In the logic handling VHost dispatch, Keter was echoing back `Host` header value, unescaped,
+as part of an HTML error page. This constitutes a reflected-XSS vulnerability. Although
+not readily exploitable directly from a browser (where `Host` header can't generally assume
+arbitrary values), it may become such in presence of further weaknesses in components
+upstream of Keter in the http proxying chain. Therefore, AC:High in CVSS evaluation.


### PR DESCRIPTION
Hi SRT! Absolutely cool undertaking; please keep it going. Here're my 5 cents.

Evaluating XSS impacts in CVSS v3.1 is rather tricky, esp. in generic context of an app-server; I took guidance from [this post][1], and IMO lowish-medium severity seems about right.

No CVE was requested; disclosure and fix happened in 2022. `keywords += ["historic"]` ?

Please review & merge.

cc @jappeace hey, look what now exists :heart_eyes: https://haskell.github.io/security-advisories/

[1]: https://security.stackexchange.com/questions/271753/cvss3-score-for-xss-leading-to-account-takeover

---

## Advisory

- [x] It's not duplicated
- [x] All fields are filled
- [ ] It is validated by `hsec-tools`

## hsec-tools

- [ ] Previous advisories are still valid
