### PR TITLE
atom: set updated to newest advisory modification date, not oldest

### DIFF
--- a/code/hsec-tools/src/Security/Advisories/Generate/HTML.hs
+++ b/code/hsec-tools/src/Security/Advisories/Generate/HTML.hs
@@ -25,7 +25,7 @@ import System.IO (hPrint, stderr)
 
 import Distribution.Pretty (prettyShow)
 import Lucid
-import Safe (minimumMay)
+import Safe (maximumMay)
 import qualified Text.Atom.Feed as Feed
 import qualified Text.Atom.Feed.Export as FeedExport
 import Validation (Validation (..))
@@ -233,7 +233,7 @@ feed advisories =
   ( Feed.nullFeed
       atomFeedUrl
       (Feed.TextString "Haskell Security Advisory DB") -- Title
-      (maybe "" (T.pack . iso8601Show) . minimumMay . fmap (zonedTimeToUTC . Advisories.advisoryModified) $ advisories)
+      (maybe "" (T.pack . iso8601Show) . maximumMay . fmap (zonedTimeToUTC . Advisories.advisoryModified) $ advisories)
   )
     { Feed.feedEntries = fmap toEntry advisories
     , Feed.feedLinks = [(Feed.nullLink atomFeedUrl) { Feed.linkRel = Just (Left "self") }]


### PR DESCRIPTION
Silly mistake.


---

## Advisory

- [ ] It's not duplicated
- [ ] All fields are filled
- [ ] It is validated by `hsec-tools`

## hsec-tools

- [ ] Previous advisories are still valid
