### PR TITLE
HSEC-2024-0003: alias CVE-2024-3566, add references

### DIFF
--- a/advisories/hackage/process/HSEC-2024-0003.md
+++ b/advisories/hackage/process/HSEC-2024-0003.md
@@ -3,12 +3,20 @@
 id = "HSEC-2024-0003"
 cwe = [150]
 keywords = ["windows"]
-aliases = ["VU#123335"]
+aliases = ["CVE-2024-3566", "VU#123335"]
 related = ["CVE-2024-1874", "CVE-2024-24576", "CVE-2024-22423"]
 
 [[references]]
 type = "ARTICLE"
 url = "https://flatt.tech/research/posts/batbadbut-you-cant-securely-execute-commands-on-windows/"
+
+[[references]]
+type = "ADVISORY"
+url = "https://kb.cert.org/vuls/id/123335"
+
+[[references]]
+type = "FIX"
+url = "https://github.com/haskell/process/commit/3c419f9eeedac024c9dccce544e5a6fb587179a5"
 
 
 [[affected]]


### PR DESCRIPTION
---

## Advisory

- [ ] It's not duplicated
- [ ] All fields are filled
- [ ] It is validated by `hsec-tools`

## hsec-tools

- [ ] Previous advisories are still valid
