### PR TITLE
osv: update package metadata

### DIFF
--- a/code/hsec-core/hsec-core.cabal
+++ b/code/hsec-core/hsec-core.cabal
@@ -13,8 +13,8 @@ description:        Core package representing Haskell advisories.
 
 -- The license under which the package is released.
 license:            BSD-3-Clause
-author:             David Christiansen
-maintainer:         david@davidchristiansen.dk
+author:             Haskell Security Response Team
+maintainer:         security-advisories@haskell.org
 
 -- A copyright notice.
 -- copyright:
@@ -32,10 +32,10 @@ library
   build-depends:
     , base          >=4.14    && <4.20
     , Cabal-syntax  >=3.8.1.0 && <3.11
-    , cvss
-    , osv
+    , cvss >= 0.1 && < 0.2
+    , osv >= 0.1 && < 0.2
     , pandoc-types  >=1.22    && <2
-    , safe          >=0.3
+    , safe          >=0.3     && <0.4
     , text          >=1.2     && <3
     , time          >=1.9     && <1.14
 

--- a/code/hsec-sync/hsec-sync.cabal
+++ b/code/hsec-sync/hsec-sync.cabal
@@ -35,7 +35,7 @@ library
     , extra        >=1.7   && <1.8
     , feed         >=1.3   && <1.4
     , filepath     >=1.4   && <1.5
-    , hsec-core
+    , hsec-core    >= 0.1  && < 0.2
     , http-client  >=0.7.0 && <0.8
     , lens         >=5.1   && <5.3
     , process      >=1.6   && <1.7

--- a/code/hsec-tools/hsec-tools.cabal
+++ b/code/hsec-tools/hsec-tools.cabal
@@ -15,8 +15,8 @@ description:
 
 -- The license under which the package is released.
 license:            BSD-3-Clause
-author:             David Christiansen
-maintainer:         david@davidchristiansen.dk
+author:             Haskell Security Response Team
+maintainer:         security-advisories@haskell.org
 
 -- A copyright notice.
 -- copyright:
@@ -46,20 +46,20 @@ library
     , commonmark            ^>=0.2.2
     , commonmark-pandoc     >=0.2      && <0.3
     , containers            >=0.6      && <0.7
-    , cvss
+    , cvss                  >= 0.1     && < 0.2
     , directory             <2
     , extra                 ^>=1.7.5
     , filepath              >=1.4      && <1.5
-    , hsec-core
+    , hsec-core             >= 0.1     && < 0.2
     , feed                  ==1.3.*
-    , lucid                 >=2.9.0
+    , lucid                 >=2.9.0    && < 3
     , mtl                   >=2.2      && <2.4
-    , osv
+    , osv                   >= 0.1     && < 0.2
     , pandoc-types          >=1.22     && <2
     , parsec                >=3        && <4
-    , pathwalk              >=0.3
+    , pathwalk              >=0.3      && < 0.4
     , process               >=1.6      && <1.7
-    , safe                  >=0.3
+    , safe                  >=0.3      && < 0.4
     , text                  >=1.2      && <3
     , time                  >=1.9      && <1.14
     , toml-parser           ^>=2.0.0.0
@@ -86,7 +86,7 @@ executable hsec-tools
     , bytestring            >=0.10    && <0.13
     , Cabal-syntax          >=3.8.1.0 && <3.11
     , filepath              >=1.4     && <1.5
-    , hsec-core
+    , hsec-core             >= 0.1    && < 0.2
     , hsec-tools
     , optparse-applicative  >=0.17    && <0.19
     , text                  >=1.2     && <3

--- a/code/osv/osv.cabal
+++ b/code/osv/osv.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               osv
-version:            0.1.0.0
+version:            0.1.0.1
 
 -- A short (one-line) description of the package.
 synopsis:
@@ -15,8 +15,8 @@ description:
 
 -- The license under which the package is released.
 license:            BSD-3-Clause
-author:             David Christiansen
-maintainer:         david@davidchristiansen.dk
+author:             Haskell Security Response Team
+maintainer:         security-advisories@haskell.org
 
 -- A copyright notice.
 -- copyright:
@@ -33,7 +33,7 @@ library
   build-depends:
     , aeson                 >=2.0.1.0  && <3
     , base                  >=4.14     && <4.20
-    , cvss
+    , cvss >= 0.1 && < 0.2
     , text                  >=1.2      && <3
     , time                  >=1.9      && <1.14
 


### PR DESCRIPTION
Add missing version bounds on `cvss`, and update maintainer.


---

## Advisory

- [ ] It's not duplicated
- [ ] All fields are filled
- [ ] It is validated by `hsec-tools`

## hsec-tools

- [ ] Previous advisories are still valid
