### PR TITLE
Add Advisory.Ecosystem to support GHC's advisory

### DIFF
--- a/code/hsec-core/src/Security/Advisories/Core/Advisory.hs
+++ b/code/hsec-core/src/Security/Advisories/Core/Advisory.hs
@@ -53,7 +53,7 @@ data Ecosystem = Hackage Text | GHC GHCComponent
 
 -- Keep this list in sync with the 'ghcComponentFromText' below
 data GHCComponent = GHCCompiler | GHCi | GHCRTS
-  deriving stock (Show, Eq)
+  deriving stock (Show, Eq, Enum, Bounded)
 
 ghcComponentToText :: GHCComponent -> Text
 ghcComponentToText c = case c of

--- a/code/hsec-core/src/Security/Advisories/Core/Advisory.hs
+++ b/code/hsec-core/src/Security/Advisories/Core/Advisory.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DerivingVia, OverloadedStrings #-}
 
 module Security.Advisories.Core.Advisory
   ( Advisory(..)
@@ -10,6 +10,10 @@ module Security.Advisories.Core.Advisory
   , AffectedVersionRange(..)
   , OS(..)
   , Keyword(..)
+  , Ecosystem(..)
+  , GHCComponent(..)
+  , ghcComponentToText
+  , ghcComponentFromText
   )
   where
 
@@ -44,10 +48,30 @@ data Advisory = Advisory
   }
   deriving stock (Show)
 
+data Ecosystem = Hackage Text | GHC GHCComponent
+  deriving stock (Show, Eq)
+
+-- Keep this list in sync with the 'ghcComponentFromText' below
+data GHCComponent = GHCCompiler | GHCi | GHCRTS
+  deriving stock (Show, Eq)
+
+ghcComponentToText :: GHCComponent -> Text
+ghcComponentToText c = case c of
+  GHCCompiler -> "compiler"
+  GHCi -> "ghci"
+  GHCRTS -> "rts"
+
+ghcComponentFromText :: Text -> Maybe GHCComponent
+ghcComponentFromText c = case c of
+  "compiler" -> Just GHCCompiler
+  "ghci" -> Just GHCi
+  "rts" -> Just GHCRTS
+  _ -> Nothing
+
 -- | An affected package (or package component).  An 'Advisory' must
 -- mention one or more packages.
 data Affected = Affected
-  { affectedPackage :: Text
+  { affectedEcosystem :: Ecosystem
   , affectedCVSS :: CVSS.CVSS
   , affectedVersions :: [AffectedVersionRange]
   , affectedArchitectures :: Maybe [Architecture]

--- a/code/hsec-core/src/Security/Advisories/Core/Advisory.hs
+++ b/code/hsec-core/src/Security/Advisories/Core/Advisory.hs
@@ -52,7 +52,7 @@ data ComponentIdentifier = Hackage Text | GHC GHCComponent
   deriving stock (Show, Eq)
 
 -- Keep this list in sync with the 'ghcComponentFromText' below
-data GHCComponent = GHCCompiler | GHCi | GHCRTS
+data GHCComponent = GHCCompiler | GHCi | GHCRTS | GHCPkg | RunGHC | IServ | HP2PS | HPC | HSC2HS | Haddock
   deriving stock (Show, Eq, Enum, Bounded)
 
 ghcComponentToText :: GHCComponent -> Text
@@ -60,12 +60,26 @@ ghcComponentToText c = case c of
   GHCCompiler -> "compiler"
   GHCi -> "ghci"
   GHCRTS -> "rts"
+  GHCPkg -> "ghc-pkg"
+  RunGHC -> "runghc"
+  IServ -> "iserv"
+  HP2PS -> "hp2ps"
+  HPC -> "hpc"
+  HSC2HS -> "hsc2hs"
+  Haddock -> "haddock"
 
 ghcComponentFromText :: Text -> Maybe GHCComponent
 ghcComponentFromText c = case c of
   "compiler" -> Just GHCCompiler
   "ghci" -> Just GHCi
   "rts" -> Just GHCRTS
+  "ghc-pkg" -> Just GHCPkg
+  "runghc" -> Just RunGHC
+  "iserv" -> Just IServ
+  "hp2ps" -> Just HP2PS
+  "hpc" -> Just HPC
+  "hsc2hs" -> Just HSC2HS
+  "haddock" -> Just Haddock
   _ -> Nothing
 
 -- | An affected package (or package component).  An 'Advisory' must

--- a/code/hsec-core/src/Security/Advisories/Core/Advisory.hs
+++ b/code/hsec-core/src/Security/Advisories/Core/Advisory.hs
@@ -57,12 +57,12 @@ data GHCComponent = GHCCompiler | GHCi | GHCRTS | GHCPkg | RunGHC | IServ | HP2P
 
 ghcComponentToText :: GHCComponent -> Text
 ghcComponentToText c = case c of
-  GHCCompiler -> "compiler"
+  GHCCompiler -> "ghc"
   GHCi -> "ghci"
   GHCRTS -> "rts"
   GHCPkg -> "ghc-pkg"
   RunGHC -> "runghc"
-  IServ -> "iserv"
+  IServ -> "ghc-iserv"
   HP2PS -> "hp2ps"
   HPC -> "hpc"
   HSC2HS -> "hsc2hs"
@@ -70,12 +70,12 @@ ghcComponentToText c = case c of
 
 ghcComponentFromText :: Text -> Maybe GHCComponent
 ghcComponentFromText c = case c of
-  "compiler" -> Just GHCCompiler
+  "ghc" -> Just GHCCompiler
   "ghci" -> Just GHCi
   "rts" -> Just GHCRTS
   "ghc-pkg" -> Just GHCPkg
   "runghc" -> Just RunGHC
-  "iserv" -> Just IServ
+  "ghc-iserv" -> Just IServ
   "hp2ps" -> Just HP2PS
   "hpc" -> Just HPC
   "hsc2hs" -> Just HSC2HS

--- a/code/hsec-core/src/Security/Advisories/Core/Advisory.hs
+++ b/code/hsec-core/src/Security/Advisories/Core/Advisory.hs
@@ -10,7 +10,7 @@ module Security.Advisories.Core.Advisory
   , AffectedVersionRange(..)
   , OS(..)
   , Keyword(..)
-  , Ecosystem(..)
+  , ComponentIdentifier(..)
   , GHCComponent(..)
   , ghcComponentToText
   , ghcComponentFromText
@@ -48,7 +48,7 @@ data Advisory = Advisory
   }
   deriving stock (Show)
 
-data Ecosystem = Hackage Text | GHC GHCComponent
+data ComponentIdentifier = Hackage Text | GHC GHCComponent
   deriving stock (Show, Eq)
 
 -- Keep this list in sync with the 'ghcComponentFromText' below
@@ -71,7 +71,7 @@ ghcComponentFromText c = case c of
 -- | An affected package (or package component).  An 'Advisory' must
 -- mention one or more packages.
 data Affected = Affected
-  { affectedEcosystem :: Ecosystem
+  { affectedComponentIdentifier :: ComponentIdentifier
   , affectedCVSS :: CVSS.CVSS
   , affectedVersions :: [AffectedVersionRange]
   , affectedArchitectures :: Maybe [Architecture]

--- a/code/hsec-tools/app/Main.hs
+++ b/code/hsec-tools/app/Main.hs
@@ -23,7 +23,7 @@ import Security.Advisories.Generate.HTML
 import Security.Advisories.Generate.Snapshot
 import Security.Advisories.Git
 import Security.Advisories.Queries (listVersionRangeAffectedBy)
-import Security.Advisories.Filesystem (parseEcosystem)
+import Security.Advisories.Filesystem (parseComponentIdentifier)
 import System.Exit (die, exitFailure, exitSuccess)
 import System.FilePath (takeBaseName)
 import System.IO (hPrint, hPutStrLn, stderr)
@@ -169,13 +169,13 @@ withAdvisory go file = do
   oob <- runExceptT $ case file of
     Nothing -> throwE StdInHasNoOOB
     Just path -> do
-     ecosystem <- parseEcosystem path
+     ecosystem <- parseComponentIdentifier path
      withExceptT GitHasNoOOB $ do
       gitInfo <- ExceptT $ liftIO $ getAdvisoryGitInfo path
       pure OutOfBandAttributes
         { oobPublished = firstAppearanceCommitDate gitInfo
         , oobModified = lastModificationCommitDate gitInfo
-        , oobEcosystem = ecosystem
+        , oobComponentIdentifier = ecosystem
         }
 
   case parseAdvisory NoOverrides oob input of

--- a/code/hsec-tools/app/Main.hs
+++ b/code/hsec-tools/app/Main.hs
@@ -23,17 +23,11 @@ import Security.Advisories.Generate.HTML
 import Security.Advisories.Generate.Snapshot
 import Security.Advisories.Git
 import Security.Advisories.Queries (listVersionRangeAffectedBy)
-
+import Security.Advisories.Filesystem (parseEcosystem)
 import System.Exit (die, exitFailure, exitSuccess)
 import System.FilePath (takeBaseName)
 import System.IO (hPrint, hPutStrLn, stderr)
 import Validation (Validation (..))
-
-import Security.Advisories.Generate.HTML
-import Security.Advisories.Filesystem (parseEcosystem)
-
-import qualified Command.Reserve
-
 
 main :: IO ()
 main =

--- a/code/hsec-tools/src/Security/Advisories/Convert/OSV.hs
+++ b/code/hsec-tools/src/Security/Advisories/Convert/OSV.hs
@@ -30,14 +30,14 @@ convert adv =
 mkAffected :: Affected -> OSV.Affected Void Void Void
 mkAffected aff =
   OSV.Affected
-    { OSV.affectedPackage = mkPackage (affectedEcosystem aff)
+    { OSV.affectedPackage = mkPackage (affectedComponentIdentifier aff)
     , OSV.affectedRanges = pure $ mkRange (affectedVersions aff)
     , OSV.affectedSeverity = [OSV.Severity (affectedCVSS aff)]
     , OSV.affectedEcosystemSpecific = Nothing
     , OSV.affectedDatabaseSpecific = Nothing
     }
 
-mkPackage :: Ecosystem -> OSV.Package
+mkPackage :: ComponentIdentifier -> OSV.Package
 mkPackage ecosystem = OSV.Package
   { OSV.packageName = packageName
   , OSV.packageEcosystem = ecosystemName

--- a/code/hsec-tools/src/Security/Advisories/Convert/OSV.hs
+++ b/code/hsec-tools/src/Security/Advisories/Convert/OSV.hs
@@ -30,19 +30,23 @@ convert adv =
 mkAffected :: Affected -> OSV.Affected Void Void Void
 mkAffected aff =
   OSV.Affected
-    { OSV.affectedPackage = mkPackage (affectedPackage aff)
+    { OSV.affectedPackage = mkPackage (affectedEcosystem aff)
     , OSV.affectedRanges = pure $ mkRange (affectedVersions aff)
     , OSV.affectedSeverity = [OSV.Severity (affectedCVSS aff)]
     , OSV.affectedEcosystemSpecific = Nothing
     , OSV.affectedDatabaseSpecific = Nothing
     }
 
-mkPackage :: T.Text -> OSV.Package
-mkPackage name = OSV.Package
-  { OSV.packageName = name
-  , OSV.packageEcosystem = "Hackage"
+mkPackage :: Ecosystem -> OSV.Package
+mkPackage ecosystem = OSV.Package
+  { OSV.packageName = packageName
+  , OSV.packageEcosystem = ecosystemName
   , OSV.packagePurl = Nothing
   }
+  where
+    (ecosystemName, packageName) = case ecosystem of
+        Hackage n -> ("Hackage", n)
+        GHC c -> ("GHC", ghcComponentToText c)
 
 mkRange :: [AffectedVersionRange] -> OSV.Range Void
 mkRange ranges =

--- a/code/hsec-tools/src/Security/Advisories/Format.hs
+++ b/code/hsec-tools/src/Security/Advisories/Format.hs
@@ -154,7 +154,7 @@ instance Toml.FromValue Affected where
       decls     <- maybe [] Map.toList <$> Toml.optKey "declarations"
       versions  <- Toml.reqKey "versions"
       pure $ Affected
-        { affectedEcosystem = ecosystem
+        { affectedComponentIdentifier = ecosystem
         , affectedCVSS = cvss
         , affectedVersions = versions
         , affectedArchitectures = arch
@@ -175,7 +175,7 @@ instance Toml.ToTable Affected where
     [ "arch" Toml..= y | Just y <- [affectedArchitectures x]] ++
     [ "declarations" Toml..= asTable (affectedDeclarations x) | not (null (affectedDeclarations x))]
     where
-      ecosystem = case affectedEcosystem x of
+      ecosystem = case affectedComponentIdentifier x of
         Hackage pkg -> ["package" Toml..= pkg]
         GHC c -> ["ghc-component" Toml..= c]
       asTable kvs = Map.fromList [(T.unpack k, v) | (k,v) <- kvs]

--- a/code/hsec-tools/src/Security/Advisories/Format.hs
+++ b/code/hsec-tools/src/Security/Advisories/Format.hs
@@ -139,8 +139,17 @@ instance Toml.ToTable AdvisoryMetadata where
 instance Toml.FromValue GHCComponent where
   fromValue v = case v of
     Toml.Text' _ n
-      | Just c <- ghcComponentFromText n -> pure c
-    _ -> Toml.failAt (Toml.valueAnn v) $ T.unpack $ "Invalid component, expected " <> T.intercalate "|" componentNames
+      | Just c <- ghcComponentFromText n
+      -> pure c
+      | otherwise
+      -> Toml.failAt (Toml.valueAnn v) $
+          "Invalid ghc-component '"
+          <> T.unpack n
+          <> "', expected "
+          <> T.unpack (T.intercalate "|" componentNames)
+    _ -> Toml.failAt (Toml.valueAnn v) $
+          "Non-text ghc-component, expected"
+          <> T.unpack (T.intercalate "|" componentNames)
    where
      componentNames = map ghcComponentToText [minBound..maxBound]
 

--- a/code/hsec-tools/src/Security/Advisories/Format.hs
+++ b/code/hsec-tools/src/Security/Advisories/Format.hs
@@ -140,7 +140,9 @@ instance Toml.FromValue GHCComponent where
   fromValue v = case v of
     Toml.Text' _ n
       | Just c <- ghcComponentFromText n -> pure c
-    _ -> Toml.failAt (Toml.valueAnn v) "Invalid component, expected compiler|ghci|rts"
+    _ -> Toml.failAt (Toml.valueAnn v) $ T.unpack $ "Invalid component, expected " <> T.intercalate "|" componentNames
+   where
+     componentNames = map ghcComponentToText [minBound..maxBound]
 
 instance Toml.ToValue GHCComponent where
   toValue = Toml.Text' () . ghcComponentToText

--- a/code/hsec-tools/src/Security/Advisories/Generate/HTML.hs
+++ b/code/hsec-tools/src/Security/Advisories/Generate/HTML.hs
@@ -35,7 +35,7 @@ import Validation (Validation (..))
 import qualified Security.Advisories as Advisories
 import Security.Advisories.Filesystem (listAdvisories)
 import Security.Advisories.Generate.TH (readDirFilesTH)
-import Security.Advisories.Core.Advisory (Ecosystem (..), ghcComponentToText)
+import Security.Advisories.Core.Advisory (ComponentIdentifier (..), ghcComponentToText)
 
 -- * Actions
 
@@ -88,7 +88,7 @@ data AdvisoryR = AdvisoryR
   deriving stock (Show)
 
 data AffectedPackageR = AffectedPackageR
-  { ecosystem :: Ecosystem,
+  { ecosystem :: ComponentIdentifier,
     introduced :: Text,
     fixed :: Maybe Text
   }
@@ -237,7 +237,7 @@ toAdvisoryR x =
     toAffectedPackageR p =
       flip map (Advisories.affectedVersions p) $ \versionRange ->
         AffectedPackageR
-          { ecosystem = Advisories.affectedEcosystem p,
+          { ecosystem = Advisories.affectedComponentIdentifier p,
             introduced = T.pack $ prettyShow $ Advisories.affectedVersionRangeIntroduced versionRange,
             fixed = T.pack . prettyShow <$> Advisories.affectedVersionRangeFixed versionRange
           }

--- a/code/hsec-tools/src/Security/Advisories/Parse.hs
+++ b/code/hsec-tools/src/Security/Advisories/Parse.hs
@@ -16,6 +16,7 @@
  , displayOOBError
  , AttributeOverridePolicy(..)
  , ParseAdvisoryError(..)
+ , validateEcosystem
  )
 where
 
@@ -208,6 +209,12 @@ parseAdvisoryTable oob policy doc summary details html tab =
         , advisorySummary = summary
         , advisoryDetails = details
         }
+
+-- | Make sure one of the affected match the ecosystem
+validateEcosystem :: MonadFail m => Ecosystem -> [Affected] -> m ()
+validateEcosystem ecosystem xs
+  | any (\affected -> affectedEcosystem affected == ecosystem) xs = pure ()
+  | otherwise = fail $ "Expected an affected to match the ecosystem: " <> show ecosystem
 
 advisoryDoc :: Blocks -> Either Text (Text, [Block])
 advisoryDoc (Many blocks) = case blocks of

--- a/code/hsec-tools/src/Security/Advisories/Queries.hs
+++ b/code/hsec-tools/src/Security/Advisories/Queries.hs
@@ -38,9 +38,10 @@ isAffectedByHelper checkWithRange queryPackageName queryVersionish =
     any checkAffected . advisoryAffected
     where
       checkAffected :: Affected -> Bool
-      checkAffected affected =
-        queryPackageName == affectedPackage affected
-          && checkWithRange queryVersionish (fromAffected affected)
+      checkAffected affected = case affectedEcosystem affected of
+        Hackage pkg -> queryPackageName == pkg && checkWithRange queryVersionish (fromAffected affected)
+        -- TODO: support GHC ecosystem query, e.g. by adding a cli flag
+        _ -> False
 
       fromAffected :: Affected -> VersionRange
       fromAffected = foldr (unionVersionRanges . fromAffectedVersionRange) noVersion . affectedVersions

--- a/code/hsec-tools/src/Security/Advisories/Queries.hs
+++ b/code/hsec-tools/src/Security/Advisories/Queries.hs
@@ -38,7 +38,7 @@ isAffectedByHelper checkWithRange queryPackageName queryVersionish =
     any checkAffected . advisoryAffected
     where
       checkAffected :: Affected -> Bool
-      checkAffected affected = case affectedEcosystem affected of
+      checkAffected affected = case affectedComponentIdentifier affected of
         Hackage pkg -> queryPackageName == pkg && checkWithRange queryVersionish (fromAffected affected)
         -- TODO: support GHC ecosystem query, e.g. by adding a cli flag
         _ -> False

--- a/code/hsec-tools/test/Spec.hs
+++ b/code/hsec-tools/test/Spec.hs
@@ -47,7 +47,7 @@ doGoldenTest fp = goldenVsString fp (fp <> ".golden") (LText.encodeUtf8 <$> doCh
             attr = OutOfBandAttributes
               { oobPublished = fakeDate
               , oobModified = fakeDate
-              , oobEcosystem = Nothing
+              , oobComponentIdentifier = Nothing
               }
             res = parseAdvisory NoOverrides (Right attr) input
             osvExport = case res of

--- a/code/hsec-tools/test/Spec.hs
+++ b/code/hsec-tools/test/Spec.hs
@@ -44,9 +44,10 @@ doGoldenTest fp = goldenVsString fp (fp <> ".golden") (LText.encodeUtf8 <$> doCh
     doCheck = do
         input <- T.readFile fp
         let fakeDate = UTCTime (fromOrdinalDate 1970 0) 0
-            attr = OutOfBandAttributes                    
+            attr = OutOfBandAttributes
               { oobPublished = fakeDate
               , oobModified = fakeDate
+              , oobEcosystem = Nothing
               }
             res = parseAdvisory NoOverrides (Right attr) input
             osvExport = case res of

--- a/code/hsec-tools/test/Spec/FormatSpec.hs
+++ b/code/hsec-tools/test/Spec/FormatSpec.hs
@@ -70,12 +70,21 @@ genAdvisoryMetadata =
 genAffected :: Gen.Gen Affected
 genAffected =
   Affected
-    <$> genText
+    <$> genEcosystem
     <*> genCVSS
     <*> Gen.list (Range.linear 0 5) genAffectedVersionRange
     <*> Gen.maybe (Gen.list (Range.linear 0 5) genArchitecture)
     <*> Gen.maybe (Gen.list (Range.linear 0 5) genOS)
     <*> (Map.toList . Map.fromList <$> Gen.list (Range.linear 0 5) ((,) <$> genText <*> genVersionRange))
+
+genEcosystem :: Gen.Gen Ecosystem
+genEcosystem = Gen.choice $
+  [ Hackage <$> genText
+  , GHC <$> genGHCComponent
+  ]
+
+genGHCComponent :: Gen.Gen GHCComponent
+genGHCComponent = Gen.choice $ map pure [minBound..maxBound]
 
 genCVSS :: Gen.Gen CVSS
 genCVSS =

--- a/code/hsec-tools/test/Spec/FormatSpec.hs
+++ b/code/hsec-tools/test/Spec/FormatSpec.hs
@@ -80,11 +80,8 @@ genAffected =
 genComponentIdentifier :: Gen.Gen ComponentIdentifier
 genComponentIdentifier = Gen.choice $
   [ Hackage <$> genText
-  , GHC <$> genGHCComponent
+  , GHC <$> Gen.enumBounded
   ]
-
-genGHCComponent :: Gen.Gen GHCComponent
-genGHCComponent = Gen.choice $ map pure [minBound..maxBound]
 
 genCVSS :: Gen.Gen CVSS
 genCVSS =

--- a/code/hsec-tools/test/Spec/FormatSpec.hs
+++ b/code/hsec-tools/test/Spec/FormatSpec.hs
@@ -70,15 +70,15 @@ genAdvisoryMetadata =
 genAffected :: Gen.Gen Affected
 genAffected =
   Affected
-    <$> genEcosystem
+    <$> genComponentIdentifier
     <*> genCVSS
     <*> Gen.list (Range.linear 0 5) genAffectedVersionRange
     <*> Gen.maybe (Gen.list (Range.linear 0 5) genArchitecture)
     <*> Gen.maybe (Gen.list (Range.linear 0 5) genOS)
     <*> (Map.toList . Map.fromList <$> Gen.list (Range.linear 0 5) ((,) <$> genText <*> genVersionRange))
 
-genEcosystem :: Gen.Gen Ecosystem
-genEcosystem = Gen.choice $
+genComponentIdentifier :: Gen.Gen ComponentIdentifier
+genComponentIdentifier = Gen.choice $
   [ Hackage <$> genText
   , GHC <$> genGHCComponent
   ]

--- a/code/hsec-tools/test/Spec/QueriesSpec.hs
+++ b/code/hsec-tools/test/Spec/QueriesSpec.hs
@@ -115,7 +115,7 @@ mkAdvisory versionRange =
      , advisoryRelated = [ "CVE-2022-YYYY" , "CVE-2022-ZZZZ" ]
      , advisoryAffected =
          [ Affected
-             { affectedEcosystem = Hackage packageName
+             { affectedComponentIdentifier = Hackage packageName
              , affectedCVSS = cvss
              , affectedVersions = mkAffectedVersions versionRange
              , affectedArchitectures = Nothing

--- a/code/hsec-tools/test/Spec/QueriesSpec.hs
+++ b/code/hsec-tools/test/Spec/QueriesSpec.hs
@@ -115,7 +115,7 @@ mkAdvisory versionRange =
      , advisoryRelated = [ "CVE-2022-YYYY" , "CVE-2022-ZZZZ" ]
      , advisoryAffected =
          [ Affected
-             { affectedPackage = packageName
+             { affectedEcosystem = Hackage packageName
              , affectedCVSS = cvss
              , affectedVersions = mkAffectedVersions versionRange
              , affectedArchitectures = Nothing

--- a/code/hsec-tools/test/golden/EXAMPLE_ADVISORY.md.golden
+++ b/code/hsec-tools/test/golden/EXAMPLE_ADVISORY.md.golden
@@ -17,7 +17,7 @@ Right
             ]
         , advisoryAffected =
             [ Affected
-                { affectedEcosystem = Hackage "package-name"
+                { affectedComponentIdentifier = Hackage "package-name"
                 , affectedCVSS = CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
                 , affectedVersions =
                     [ AffectedVersionRange

--- a/code/hsec-tools/test/golden/EXAMPLE_ADVISORY.md.golden
+++ b/code/hsec-tools/test/golden/EXAMPLE_ADVISORY.md.golden
@@ -17,7 +17,7 @@ Right
             ]
         , advisoryAffected =
             [ Affected
-                { affectedPackage = "package-name"
+                { affectedEcosystem = Hackage "package-name"
                 , affectedCVSS = CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
                 , affectedVersions =
                     [ AffectedVersionRange


### PR DESCRIPTION
This change adds a new OOB to pass the Ecosystem value from the advisory path.

Fixes #212 