### PR TITLE
Remove CVSS v2 prefix from vector string

### DIFF
--- a/advisories/hackage/xmonad-contrib/HSEC-2023-0003.md
+++ b/advisories/hackage/xmonad-contrib/HSEC-2023-0003.md
@@ -7,7 +7,7 @@ aliases = ["CVE-2013-1436"]
 
 [[affected]]
 package = "xmonad-contrib"
-cvss = "CVSS:2.0/AV:N/AC:L/Au:N/C:P/I:P/A:P"
+cvss = "AV:N/AC:L/Au:N/C:P/I:P/A:P"
 [[affected.versions]]
 introduced = "0.5"
 fixed = "0.11.2"

--- a/code/cvss/CHANGELOG.md
+++ b/code/cvss/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2
+
+Changed the CVSS v2 parser and printer to omit the "CVSS:2.0/" version prefix according to the spec.
+
 # 0.1
 
 Introduction

--- a/code/cvss/cvss.cabal
+++ b/code/cvss/cvss.cabal
@@ -1,6 +1,6 @@
 cabal-version:   2.4
 name:            cvss
-version:         0.1
+version:         0.2
 synopsis:        Common Vulnerability Scoring System.
 description:
   Use this library to parse CVSS string and compute its score.

--- a/code/cvss/src/Security/CVSS.hs
+++ b/code/cvss/src/Security/CVSS.hs
@@ -110,6 +110,7 @@ parseCVSS :: Text -> Either CVSSError CVSS
 parseCVSS txt
   | "CVSS:3.1/" `Text.isPrefixOf` txt = CVSS CVSS31 <$> validateComponents True validateCvss31
   | "CVSS:3.0/" `Text.isPrefixOf` txt = CVSS CVSS30 <$> validateComponents True validateCvss30
+  | "CVSS:" `Text.isPrefixOf` txt = Left UnknownVersion
   | otherwise = CVSS CVSS20 <$> validateComponents False validateCvss20
   where
     validateComponents withPrefix validator = do

--- a/code/cvss/test/Spec.hs
+++ b/code/cvss/test/Spec.hs
@@ -30,7 +30,7 @@ examples =
     , ("CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N", 4.0, CVSS.Medium)
     , ("CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H", 9.9, CVSS.Critical)
     , ("CVSS:3.0/AV:L/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:L", 4.2, CVSS.Medium)
-    , ("CVSS:2.0/AV:N/AC:L/Au:N/C:N/I:N/A:C", 7.8, CVSS.High)
-    , ("CVSS:2.0/AV:N/AC:L/Au:N/C:C/I:C/A:C", 10, CVSS.Critical)
-    , ("CVSS:2.0/AV:L/AC:H/Au:N/C:C/I:C/A:C", 6.2, CVSS.Medium)
+    , ("AV:N/AC:L/Au:N/C:N/I:N/A:C", 7.8, CVSS.High)
+    , ("AV:N/AC:L/Au:N/C:C/I:C/A:C", 10, CVSS.Critical)
+    , ("AV:L/AC:H/Au:N/C:C/I:C/A:C", 6.2, CVSS.Medium)
     ]

--- a/code/hsec-core/hsec-core.cabal
+++ b/code/hsec-core/hsec-core.cabal
@@ -32,7 +32,7 @@ library
   build-depends:
     , base          >=4.14    && <4.20
     , Cabal-syntax  >=3.8.1.0 && <3.11
-    , cvss >= 0.1 && < 0.2
+    , cvss >= 0.2 && < 0.3
     , osv >= 0.1 && < 0.2
     , pandoc-types  >=1.22    && <2
     , safe          >=0.3     && <0.4

--- a/code/hsec-tools/hsec-tools.cabal
+++ b/code/hsec-tools/hsec-tools.cabal
@@ -57,7 +57,7 @@ library
     , commonmark            ^>=0.2.2
     , commonmark-pandoc     >=0.2      && <0.3
     , containers            >=0.6      && <0.7
-    , cvss                  >= 0.1     && < 0.2
+    , cvss                  >= 0.2     && < 0.3
     , data-default          >=0.7      && <0.8
     , directory             <2
     , extra                 ^>=1.7.5

--- a/code/hsec-tools/test/Spec/FormatSpec.hs
+++ b/code/hsec-tools/test/Spec/FormatSpec.hs
@@ -91,9 +91,9 @@ genCVSS =
         "CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
         "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H",
         "CVSS:3.0/AV:L/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:L",
-        "CVSS:2.0/AV:N/AC:L/Au:N/C:N/I:N/A:C",
-        "CVSS:2.0/AV:N/AC:L/Au:N/C:C/I:C/A:C",
-        "CVSS:2.0/AV:L/AC:H/Au:N/C:C/I:C/A:C"
+        "AV:N/AC:L/Au:N/C:N/I:N/A:C",
+        "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+        "AV:L/AC:H/Au:N/C:C/I:C/A:C"
       ]
 
 genCAPEC :: Gen.Gen CAPEC

--- a/code/osv/osv.cabal
+++ b/code/osv/osv.cabal
@@ -33,7 +33,7 @@ library
   build-depends:
     , aeson                 >=2.0.1.0  && <3
     , base                  >=4.14     && <4.20
-    , cvss >= 0.1 && < 0.2
+    , cvss                  >=0.2      && <0.3
     , text                  >=1.2      && <3
     , time                  >=1.9      && <1.14
 


### PR DESCRIPTION
This change fix the OSV export.

Fixes #217 

## hsec-tools

- [ ] Previous advisories are still valid
