### PR TITLE
hsec-tools: include affected FilePath with parse errors

### DIFF
--- a/code/hsec-tools/src/Security/Advisories/Filesystem.hs
+++ b/code/hsec-tools/src/Security/Advisories/Filesystem.hs
@@ -121,13 +121,15 @@ forAdvisory root go = do
 -- | List deduplicated parsed Advisories
 listAdvisories
   :: (MonadIO m)
-  => FilePath -> m (Validation [ParseAdvisoryError] [Advisory])
+  => FilePath -> m (Validation [(FilePath, ParseAdvisoryError)] [Advisory])
 listAdvisories root =
   forAdvisory root $ \advisoryPath _advisoryId -> do
     isSym <- liftIO $ pathIsSymbolicLink advisoryPath
     if isSym
       then return $ pure []
-      else bimap return return <$> advisoryFromFile advisoryPath
+      else
+        bimap (\err -> [(advisoryPath, err)]) pure
+        <$> advisoryFromFile advisoryPath
 
 -- | Parse an advisory from a file system path
 advisoryFromFile

--- a/code/hsec-tools/src/Security/Advisories/Queries.hs
+++ b/code/hsec-tools/src/Security/Advisories/Queries.hs
@@ -50,16 +50,24 @@ isAffectedByHelper checkWithRange queryPackageName queryVersionish =
         (orLaterVersion (affectedVersionRangeIntroduced avr))
         (maybe anyVersion earlierVersion (affectedVersionRangeFixed avr))
 
+type QueryResult = Validation [(FilePath, ParseAdvisoryError)] [Advisory]
+
 -- | List the advisories matching a package name and a version
-listVersionAffectedBy :: MonadIO m => FilePath -> Text -> Version -> m (Validation [ParseAdvisoryError] [Advisory])
+listVersionAffectedBy
+  :: MonadIO m
+  => FilePath -> Text -> Version -> m QueryResult
 listVersionAffectedBy = listAffectedByHelper isVersionAffectedBy
 
 -- | List the advisories matching a package name and a version range
-listVersionRangeAffectedBy :: MonadIO m => FilePath -> Text -> VersionRange -> m (Validation [ParseAdvisoryError] [Advisory])
+listVersionRangeAffectedBy
+  :: (MonadIO m)
+  => FilePath -> Text -> VersionRange -> m QueryResult
 listVersionRangeAffectedBy = listAffectedByHelper isVersionRangeAffectedBy
 
 -- | Helper function for 'listVersionAffectedBy' and 'listVersionRangeAffectedBy'
-listAffectedByHelper :: MonadIO m => (Text -> a -> Advisory -> Bool) -> FilePath -> Text -> a -> m (Validation [ParseAdvisoryError] [Advisory])
+listAffectedByHelper
+  :: (MonadIO m)
+  => (Text -> a -> Advisory -> Bool) -> FilePath -> Text -> a -> m QueryResult
 listAffectedByHelper checkAffectedBy root queryPackageName queryVersionish =
   fmap (filter (checkAffectedBy queryPackageName queryVersionish)) <$>
     listAdvisories root


### PR DESCRIPTION
The `listAdvisories` error type is `[ParseAdvisoryError]`.  The error values do not have context indicating the file that caused the error.  As a result, the error message(s) do not point to the problematic file(s).

Update the error type to `[(FilePath, ParseAdvisoryError)]`; each parse error is paired with the path to the problematic file.  As a result, user error messages are much more useful.


---

## hsec-tools

- [ ] Previous advisories are still valid
