### PR TITLE
html: fix missing <tr> on by-packages index

### DIFF
--- a/code/hsec-tools/src/Security/Advisories/Generate/HTML.hs
+++ b/code/hsec-tools/src/Security/Advisories/Generate/HTML.hs
@@ -147,10 +147,13 @@ listByPackages advisories =
             let sortedAdvisories =
                     sortOn (Down . advisoryId . fst) perPackageAdvisory
             forM_ sortedAdvisories $ \(advisory, package) -> do
-              td_ [class_ "advisory-id"] $ a_ [href_ $ advisoryLink $ advisoryId advisory] $ toHtml (Advisories.printHsecId $ advisoryId advisory)
-              td_ [class_ "advisory-introduced"] $ toHtml $ introduced package
-              td_ [class_ "advisory-fixed"] $ maybe (return ()) toHtml $ fixed package
-              td_ [class_ "advisory-summary"] $ toHtml $ advisorySummary advisory
+              tr_ $ do
+                td_ [class_ "advisory-id"] $
+                  a_ [href_ $ advisoryLink $ advisoryId advisory] $
+                    toHtml (Advisories.printHsecId $ advisoryId advisory)
+                td_ [class_ "advisory-introduced"] $ toHtml $ introduced package
+                td_ [class_ "advisory-fixed"] $ maybe (return ()) toHtml $ fixed package
+                td_ [class_ "advisory-summary"] $ toHtml $ advisorySummary advisory
 
 indexDescription :: Html ()
 indexDescription =


### PR DESCRIPTION
Presentation of packages/components that have multiple advisories is corrupted, due to missing <tr> parent elements.  Data cells for multiple advisories are appearing in a single row.  Add missing <tr> elements.

Before:

![image](https://github.com/user-attachments/assets/724018d8-acab-4f21-8163-7e237522adef)


After:

![image](https://github.com/user-attachments/assets/a4bbebcd-68df-44a0-b3ac-4f23922d7606)


---

## Advisory

- [ ] It's not duplicated
- [ ] All fields are filled
- [ ] It is validated by `hsec-tools`

## hsec-tools

- [ ] Previous advisories are still valid
