### PR TITLE
HSEC-2024-0001: update keywords: historic -> historical

### DIFF
--- a/advisories/hackage/keter/HSEC-2024-0001.md
+++ b/advisories/hackage/keter/HSEC-2024-0001.md
@@ -2,7 +2,7 @@
 [advisory]
 id = "HSEC-2024-0001"
 cwe = [79]
-keywords = ["http", "xss", "rxss", "historic"]
+keywords = ["http", "xss", "rxss", "historical"]
 
 [[references]]
 type = "FIX"


### PR DESCRIPTION
Other historical advisories use keyword "historical" rather than "historic".  Align HSEC-2024-0001 with this convention.

On the difference between "historic" and "historical", see https://en.wiktionary.org/wiki/historical#Usage_notes.

---

## Advisory

- [ ] It's not duplicated
- [ ] All fields are filled
- [ ] It is validated by `hsec-tools`