### PR TITLE
add next-id command

### DIFF
--- a/EXAMPLE_ADVISORY.md
+++ b/EXAMPLE_ADVISORY.md
@@ -1,6 +1,8 @@
 ```toml
 
 [advisory]
+# Submit PRs with HSEC-0000-0000, or run `hsec-tools next-id` to
+# print the next available ID.
 id = "HSEC-0000-0000"
 cwe = []
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ to remove the explanatory comments for each field.
 [advisory]
 # Identifier for the advisory (mandatory). Will be assigned a "HSEC-YYYY-NNNN"
 # identifier e.g. HSEC-2022-0001. Please use "HSEC-0000-0000" in PRs.
+# Or run `hsec-tools next-id` to print the next available ID.
 id = "HSEC-0000-0000"
 
 # Publication date of the advisory as an RFC 3339 date.

--- a/code/hsec-tools/app/Command/NextID.hs
+++ b/code/hsec-tools/app/Command/NextID.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Command.NextID where
+
+import Control.Monad (unless)
+import Data.Maybe (fromMaybe)
+import System.Exit (die)
+
+import Security.Advisories.Git (getRepoRoot)
+import Security.Advisories.Core.HsecId (printHsecId, getNextHsecId)
+import Security.Advisories.Filesystem (isSecurityAdvisoriesRepo, getGreatestId)
+
+runNextIDCommand :: Maybe FilePath -> IO ()
+runNextIDCommand mPath = do
+  let
+    path = fromMaybe "." mPath
+  repoPath <- getRepoRoot path >>= \case
+    Left _ -> die "Not a git repo"
+    Right a -> pure a
+  isRepo <- isSecurityAdvisoriesRepo repoPath
+  unless isRepo $
+    die "Not a security-advisories repo"
+
+  getGreatestId repoPath >>= getNextHsecId >>= putStrLn . printHsecId

--- a/code/hsec-tools/app/Command/NextID.hs
+++ b/code/hsec-tools/app/Command/NextID.hs
@@ -1,24 +1,10 @@
-{-# LANGUAGE LambdaCase #-}
-
 module Command.NextID where
 
-import Control.Monad (unless)
-import Data.Maybe (fromMaybe)
-import System.Exit (die)
-
-import Security.Advisories.Git (getRepoRoot)
 import Security.Advisories.Core.HsecId (printHsecId, getNextHsecId)
-import Security.Advisories.Filesystem (isSecurityAdvisoriesRepo, getGreatestId)
+import Security.Advisories.Filesystem (getGreatestId)
+
+import Util (ensureRepo)
 
 runNextIDCommand :: Maybe FilePath -> IO ()
-runNextIDCommand mPath = do
-  let
-    path = fromMaybe "." mPath
-  repoPath <- getRepoRoot path >>= \case
-    Left _ -> die "Not a git repo"
-    Right a -> pure a
-  isRepo <- isSecurityAdvisoriesRepo repoPath
-  unless isRepo $
-    die "Not a security-advisories repo"
-
-  getGreatestId repoPath >>= getNextHsecId >>= putStrLn . printHsecId
+runNextIDCommand mPath =
+  ensureRepo mPath >>= getGreatestId >>= getNextHsecId >>= putStrLn . printHsecId

--- a/code/hsec-tools/app/Command/Reserve.hs
+++ b/code/hsec-tools/app/Command/Reserve.hs
@@ -2,8 +2,7 @@
 
 module Command.Reserve where
 
-import Control.Monad (unless, when)
-import Data.Maybe (fromMaybe)
+import Control.Monad (when)
 import System.Exit (die)
 import System.FilePath ((</>), (<.>))
 
@@ -11,7 +10,6 @@ import Security.Advisories.Git
   ( add
   , commit
   , explainGitError
-  , getRepoRoot
   )
 import Security.Advisories.Core.HsecId
   ( placeholder
@@ -21,9 +19,10 @@ import Security.Advisories.Core.HsecId
 import Security.Advisories.Filesystem
   ( dirNameAdvisories
   , dirNameReserved
-  , isSecurityAdvisoriesRepo
   , getGreatestId
   )
+
+import Util (ensureRepo)
 
 -- | How to choose IDs when creating advisories or
 -- reservations.
@@ -40,14 +39,7 @@ data CommitFlag = Commit | DoNotCommit
 
 runReserveCommand :: Maybe FilePath -> IdMode -> CommitFlag -> IO ()
 runReserveCommand mPath idMode commitFlag = do
-  let
-    path = fromMaybe "." mPath
-  repoPath <- getRepoRoot path >>= \case
-    Left _ -> die "Not a git repo"
-    Right a -> pure a
-  isRepo <- isSecurityAdvisoriesRepo repoPath
-  unless isRepo $
-    die "Not a security-advisories repo"
+  repoPath <- ensureRepo mPath
 
   hsid <- case idMode of
     IdModePlaceholder -> pure placeholder

--- a/code/hsec-tools/app/Main.hs
+++ b/code/hsec-tools/app/Main.hs
@@ -2,7 +2,6 @@
 
 module Main where
 
-import qualified Command.Reserve
 import Control.Monad (forM_, join, void, when)
 import Control.Monad.Trans.Except (runExceptT, ExceptT (ExceptT), withExceptT, throwE)
 import Control.Monad.IO.Class (liftIO)
@@ -29,6 +28,9 @@ import System.FilePath (takeBaseName)
 import System.IO (hPrint, hPutStrLn, stderr)
 import Validation (Validation (..))
 
+import qualified Command.Reserve
+import qualified Command.NextID
+
 main :: IO ()
 main =
   join $
@@ -43,6 +45,7 @@ cliOpts = info (commandsParser <**> helper) (fullDesc <> header "Haskell Advisor
     commandsParser =
       hsubparser
         ( command "check" (info commandCheck (progDesc "Syntax check a single advisory"))
+            <> command "next-id" (info commandNextID (progDesc "Print the next available HSEC ID"))
             <> command "reserve" (info commandReserve (progDesc "Reserve an HSEC ID"))
             <> command "osv" (info commandOsv (progDesc "Convert a single advisory to OSV"))
             <> command "render" (info commandRender (progDesc "Render a single advisory as HTML"))
@@ -75,6 +78,11 @@ commandReserve =
       ( long "commit"
           <> help "Commit the reservation file"
       )
+
+commandNextID :: Parser (IO ())
+commandNextID =
+  Command.NextID.runNextIDCommand
+    <$> optional (argument str (metavar "REPO"))
 
 commandCheck :: Parser (IO ())
 commandCheck =

--- a/code/hsec-tools/app/Util.hs
+++ b/code/hsec-tools/app/Util.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Util where
+
+import Data.Maybe (fromMaybe)
+import System.Exit (die)
+
+import Security.Advisories.Filesystem (isSecurityAdvisoriesRepo)
+import Security.Advisories.Git (getRepoRoot)
+
+-- | Ensure the given path (or current directory "." if @Nothing@)
+-- is an advisory Git repo.  Return the (valid) repo root, or die
+-- with an error message.
+--
+ensureRepo :: Maybe FilePath -> IO FilePath
+ensureRepo mPath =
+  getRepoRoot (fromMaybe "." mPath) >>= \case
+    Left _          -> die "Not a git repo"
+    Right repoPath  -> isSecurityAdvisoriesRepo repoPath >>= \case
+      False -> die "Not a security-advisories repo"
+      True  -> pure repoPath

--- a/code/hsec-tools/hsec-tools.cabal
+++ b/code/hsec-tools/hsec-tools.cabal
@@ -92,6 +92,7 @@ executable hsec-tools
   main-is:          Main.hs
   other-modules:    Command.Reserve
                     , Command.NextID
+                    , Util
 
   -- Modules included in this executable, other than Main.
   -- other-modules:

--- a/code/hsec-tools/hsec-tools.cabal
+++ b/code/hsec-tools/hsec-tools.cabal
@@ -91,6 +91,7 @@ library
 executable hsec-tools
   main-is:          Main.hs
   other-modules:    Command.Reserve
+                    , Command.NextID
 
   -- Modules included in this executable, other than Main.
   -- other-modules:


### PR DESCRIPTION
Add `hsec-tools next-id` command, which prints the next available HSEC ID.

Also perform a minor refactor, extracting repo directory checks to a common utility function.