### PR TITLE
chore: bump major dependencies (hsec-tools, hsec-sync, osv)

### DIFF
--- a/code/hsec-sync/hsec-sync.cabal
+++ b/code/hsec-sync/hsec-sync.cabal
@@ -1,6 +1,6 @@
 cabal-version:   2.4
 name:            hsec-sync
-version:         0.2.0.0
+version:         0.2.0.1
 
 -- A short (one-line) description of the package.
 synopsis:        Synchronize with the Haskell security advisory database
@@ -31,21 +31,21 @@ library
 
   build-depends:
     , aeson         >=2.0   && <2.3
-    , base          >=4.14  && <4.20
+    , base          >=4.14  && <4.21
     , bytestring    >=0.10  && <0.13
     , directory     >=1.3   && <1.4
     , either        >=5.0   && <5.1
     , extra         >=1.7   && <1.8
     , feed          >=1.3   && <1.4
-    , filepath      >=1.4   && <1.5
+    , filepath      >=1.4   && <1.6
     , hsec-core     ^>=0.2
     , http-client   >=0.7.0 && <0.8
-    , lens          >=5.1   && <5.3
+    , lens          >=5.1   && <5.4
     , tar           >=0.5   && <0.7
     , tar-conduit   >=0.3   && <0.5
     , temporary     >=1     && <2
     , text          >=1.2   && <3
-    , time          >=1.9   && <1.14
+    , time          >=1.9   && <1.15
     , transformers  >=0.5   && <0.7
     , wreq          >=0.5   && <0.6
     , zlib          >=0.6   && <0.8

--- a/code/hsec-tools/hsec-tools.cabal
+++ b/code/hsec-tools/hsec-tools.cabal
@@ -51,8 +51,8 @@ library
 
   build-depends:
     , aeson                 >=2.0.1.0  && <3
-    , base                  >=4.14     && <4.20
-    , bytestring            >=0.10    && <0.13
+    , base                  >=4.14     && <4.21
+    , bytestring            >=0.10     && <0.14
     , Cabal-syntax          >=3.8.1.0  && <3.13
     , commonmark            ^>=0.2.2
     , commonmark-pandoc     >=0.2      && <0.3
@@ -71,11 +71,11 @@ library
     , pandoc                >=2.0      && <3.2
     , pandoc-types          >=1.22     && <2
     , parsec                >=3        && <4
-    , pathwalk              >=0.3      && < 0.4
+    , pathwalk              >=0.3      && <0.4
     , pretty                >=1.0      && <1.2
     , prettyprinter         >=1.7      && <1.8
     , process               >=1.6      && <1.7
-    , safe                  >=0.3      && < 0.4
+    , safe                  >=0.3      && <0.4
     , text                  >=1.2      && <3
     , template-haskell      >=2.16.0.0 && <2.23
     , time                  >=1.9      && <1.14

--- a/code/osv/osv.cabal
+++ b/code/osv/osv.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               osv
-version:            0.1.0.1
+version:            0.1.0.2
 
 -- A short (one-line) description of the package.
 synopsis:
@@ -32,10 +32,10 @@ library
 
   build-depends:
     , aeson                 >=2.0.1.0  && <3
-    , base                  >=4.14     && <4.20
+    , base                  >=4.14     && <4.21
     , cvss                  >=0.2      && <0.3
     , text                  >=1.2      && <3
-    , time                  >=1.9      && <1.14
+    , time                  >=1.9      && <1.15
 
   hs-source-dirs:   src
   default-language: Haskell2010


### PR DESCRIPTION
---

## hsec-tools

- [x] Previous advisories are still valid
