### PR TITLE
HSEC-2024-0003: advise fixed in GHC 9.8.3

### DIFF
--- a/advisories/hackage/process/HSEC-2024-0003.md
+++ b/advisories/hackage/process/HSEC-2024-0003.md
@@ -146,7 +146,7 @@ releases were the first in their series to include a fixed version
 of the *process* library:
 
 - **GHC 9.10.1-alpha3** (released 2024-04-15)
-- GHC 9.8.x (**no release with fix yet**)
+- **GHC 9.8.3** (released 2024-10-20)
 - **GHC 9.6.5** (released 2024-04-16)
 
 Such a change in semantics should normally result in a major version


### PR DESCRIPTION
minor update to document that the fixed version of process was included in GHC 9.8.3, which was released in October.
