### PR TITLE
feat: rework index's advisory page

### DIFF
--- a/code/hsec-tools/assets/css/default.css
+++ b/code/hsec-tools/assets/css/default.css
@@ -150,3 +150,7 @@ footer .HF{
         display:inline
     }
 }
+
+#advisory dt {
+    margin-top: 0.75em;
+}


### PR DESCRIPTION
I have reworked advisory page for the index:

![image](https://github.com/user-attachments/assets/b656686a-2efa-42a7-9866-047fa4ee7b3b)



---

## hsec-tools

- [x] Previous advisories are still valid
