### PR TITLE
Add HSEC-2025-0001 GHC Subword division operations

### DIFF
--- a/advisories/ghc/ghc/HSEC-2025-0001.md
+++ b/advisories/ghc/ghc/HSEC-2025-0001.md
@@ -1,0 +1,32 @@
+```toml
+[advisory]
+id = "HSEC-2025-0001"
+cwe = [682]
+keywords = ["integrity", "dos"]
+
+[[affected]]
+ghc-component = "ghc"
+cvss = "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:H"
+
+[[affected.versions]]
+introduced = "9.12.1"
+fixed = "9.12.2"
+
+[[references]]
+type = "REPORT"
+url = "https://gitlab.haskell.org/ghc/ghc/-/issues/25653"
+
+[[references]]
+type = "REPORT"
+url = "https://discourse.haskell.org/t/psa-correctness-issue-in-ghc-9-12/11204"
+
+[[references]]
+type = "FIX"
+url = "https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13820"
+```
+
+# Subword division operations may produce incorrect results
+
+Arithmetic operations may produce incorrect results when compiled with optimizations.
+For the most part, this bug only causes availability and data integrity issues.
+However, in some circumstances, it may result in other, more complicated security related flaws, such as buffer overflow conditions.


### PR DESCRIPTION
## Advisory

- [x] It's not duplicated
- [x] All fields are filled
- [ ] It is validated by `hsec-tools`

Fixes #265 