### PR TITLE
advisory: Double Public Key Signing Function Oracle Attack on Ed25519

### DIFF
--- a/advisories/hackage/crypton/HSEC-2025-0002.md
+++ b/advisories/hackage/crypton/HSEC-2025-0002.md
@@ -1,0 +1,1 @@
+../cryptonite/HSEC-2025-0002.md

--- a/advisories/hackage/cryptonite/HSEC-2025-0002.md
+++ b/advisories/hackage/cryptonite/HSEC-2025-0002.md
@@ -1,0 +1,66 @@
+```toml
+[advisory]
+id = "HSEC-2025-0002"
+cwe = []
+keywords = ["crypto"]
+related = ["GHSA-w5vr-6qhr-36cc"]
+
+[[affected]]
+package = "cryptonite"
+cvss = "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:N/I:H/A:N"
+[[affected.versions]]
+introduced = "0.1"
+
+[[affected]]
+package = "crypton"
+cvss = "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:N/I:H/A:N"
+[[affected.versions]]
+introduced = "0.31"
+fixed = "1.0.3"
+
+[[references]]
+type = "ARTICLE"
+url = "https://portswigger.net/daily-swig/dozens-of-cryptography-libraries-vulnerable-to-private-key-theft"
+[[references]]
+type = "ARTICLE"
+url = "https://github.com/MystenLabs/ed25519-unsafe-libs"
+[[references]]
+type = "ADVISORY"
+url = "https://github.com/advisories/GHSA-w5vr-6qhr-36cc"
+[[references]]
+type = "EVIDENCE"
+url = "https://hackage.haskell.org/package/cryptonite-0.30/docs/src/Crypto.PubKey.Ed25519.html#sign"
+[[references]]
+type = "EVIDENCE"
+url = "https://github.com/haskell-crypto/cryptonite/blob/cryptonite-v0.30/cbits/ed25519/ed25519.c#53"
+[[references]]
+type = "EVIDENCE"
+url = "https://github.com/kazu-yamamoto/crypton/blob/48fb9df2de5ee752196724b081f4d3cdb57576ed/cbits/ed25519/ed25519.c#L53"
+[[references]]
+type = "FIX"
+url = "https://github.com/kazu-yamamoto/crypton/pull/47"
+
+```
+
+# Double Public Key Signing Function Oracle Attack on Ed25519
+
+The standard specification of Ed25519 message signing involves providing the
+algorithm with a message and private key.
+
+The function will use the private key to compute the public key and sign the message.
+Some libraries provide a variant of the message signing function that also takes
+the pre-computed public key as an input parameter.
+
+Libraries that allow arbitrary public keys as inputs without checking if the
+input public key corresponds to the input private key are vulnerable to the
+following attack.
+
+By using several public keys and messages, a malicious user with access to the
+signing mechanism may build up insights into the private key parameters
+resulting in access to the private key.
+
+This shortcoming means that an attacker could use the signing function as an
+Oracle, perform crypto-analysis and ultimately get at secrets.
+For example, an attacker who can’t access the private key but can access
+the signing mechanism through an API call could use several public keys and
+messages to gradually build up insights into private key parameters.


### PR DESCRIPTION
---

## Advisory

- [x] It's not duplicated
- [x] All fields are filled
- [x] It is validated by `hsec-tools`

Discussed here: https://github.com/awakesecurity/gen-ed25-keypair/issues/8#issuecomment-2745975829