### PR TITLE
HSEC-2025-0003: add xz-clib advisory

### DIFF
--- a/advisories/hackage/xz-clib/HSEC-2025-0003.md
+++ b/advisories/hackage/xz-clib/HSEC-2025-0003.md
@@ -1,0 +1,35 @@
+```toml
+[advisory]
+id = "HSEC-2025-0003"
+cwe = [416]
+keywords = ["corruption", "vendored-code", "language-c"]
+aliases = ["CVE-2025-31115"]
+
+[[references]]
+type = "ARTICLE"
+url = "https://tukaani.org/xz/threaded-decoder-early-free.html"
+
+[[references]]
+type = "FIX"
+url = "https://github.com/tukaani-project/xz/commit/d5a2ffe41bb77b918a8c96084885d4dbe4bf6480"
+
+[[affected]]
+package = "xz-clib"
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L"
+
+[[affected.versions]]
+introduced = "5.6.3"
+```
+
+# Use after free in multithreaded lzma (.xz) decoder
+
+In XZ Utils 5.3.3alpha to 5.8.0, the multithreaded .xz decoder in
+liblzma has a bug where invalid input can at least result in a crash
+(CVE-2025-31115). The effects include heap use after free and
+writing to an address based on the null pointer plus an offset.
+Applications and libraries that use the `lzma_stream_decoder_mt`
+function are affected.
+
+The Haskell *xz-clib* library vendors and builds the C
+implementation.  The *xz* package does not use the multithreaded
+decoder and is therefore unaffected.


### PR DESCRIPTION
Closes: https://github.com/haskell/security-advisories/issues/270 

---

## Advisory

- [ ] It's not duplicated
- [ ] All fields are filled
- [ ] It is validated by `hsec-tools`
