### PR TITLE
HSEC-2025-0003: add xz-clib fix version

### DIFF
--- a/advisories/hackage/xz-clib/HSEC-2025-0003.md
+++ b/advisories/hackage/xz-clib/HSEC-2025-0003.md
@@ -13,12 +13,17 @@ url = "https://tukaani.org/xz/threaded-decoder-early-free.html"
 type = "FIX"
 url = "https://github.com/tukaani-project/xz/commit/d5a2ffe41bb77b918a8c96084885d4dbe4bf6480"
 
+[[references]]
+type = "FIX"
+url = "https://github.com/hasufell/lzma-static/pull/14"
+
 [[affected]]
 package = "xz-clib"
 cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L"
 
 [[affected.versions]]
 introduced = "5.6.3"
+fixed = "5.8.1"
 ```
 
 # Use after free in multithreaded lzma (.xz) decoder


### PR DESCRIPTION
Closes: #270 

## Advisory

- [ ] It's not duplicated
- [ ] All fields are filled
- [ ] It is validated by `hsec-tools`
