### PR TITLE
HSEC-2025-0004: add spacecookie library vulnerability

### DIFF
--- a/advisories/hackage/spacecookie/HSEC-2025-0004.md
+++ b/advisories/hackage/spacecookie/HSEC-2025-0004.md
@@ -1,0 +1,36 @@
+```toml
+
+[advisory]
+id = "HSEC-2025-0004"
+cwe = [23]
+capec = [126]
+keywords = ["gopher", "path-traversal"]
+
+aliases = []
+related = []
+
+[[affected]]
+package = "spacecookie"
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+
+declarations = { "Network.Gopher.Util.santinizePath" = ">= 0.2.0.0 && < 1.0", "Network.Gopher.Util.santinizeIfNotUrl" = ">= 0.2.0.0 && < 1.0", "Network.Gopher.Util.sanitizePath" = ">= 1.0.0.0 && < 1.0.0.3", "Network.Gopher.Util.sanitizeIfNotUrl" = ">= 1.0.0.0 && < 1.0.0.3" }
+
+[[affected.versions]]
+introduced = "0.2.0.0"
+fixed = "1.0.0.3"
+
+[[references]]
+type = "FIX"
+url = "https://github.com/sternenseemann/spacecookie/commit/2854a8a70833e7abdeeff3c02596a6f2a2f35c61"
+```
+
+# Broken Path Sanitization in spacecookie Library
+
+The spacecookie library exposes the functions `sanitizePath` and `sanitizeIfNotUrl` intended to
+remove `..` components from paths which can be used to prevent path traversal attacks. Due to
+erroneous comparison code, this elimination is not actually performed which has been remedied
+in version 1.0.0.3 by properly comparing using `equalFilePath`.
+
+Any user of those respective functions of any version of spacecookie should upgrade to 1.0.0.3
+or later. Note that the spacecookie server executable included in the same package is not affected
+by the problem since a separate check would reject any malicious path that gets by `sanitizePath`.


### PR DESCRIPTION
---

## Advisory

- [x] It's not duplicated
- [x] All fields are filled
- [x] It is validated by `hsec-tools`

## hsec-tools

- [ ] Previous advisories are still valid
