### PR TITLE
meeting-notes: 2025-06-12

### DIFF
--- a/meeting-notes/2025-05-28.md
+++ b/meeting-notes/2025-05-28.md
@@ -1,7 +1,7 @@
 # SRT meeting 2025-05-28
 
 Previously:
-https://github.com/haskell/security-advisories/blob/main/meeting-notes/2025-05-28.md
+https://github.com/haskell/security-advisories/blob/main/meeting-notes/2025-05-15.md
 
 ## haskell.org listing vulnerability report
 

--- a/meeting-notes/2025-06-12.md
+++ b/meeting-notes/2025-06-12.md
@@ -1,0 +1,23 @@
+# SRT meeting 2025-06-12
+
+Attended: Gautier, Fraser
+
+Previously:
+https://github.com/haskell/security-advisories/blob/main/meeting-notes/2025-05-28.md
+
+## ZuriHac recap
+
+- Gautier and Tristan (and Jose) attended.
+- purl support PR:
+  https://github.com/haskell/security-advisories/pull/282
+- Flora overall happy with our library support.
+- We need to implement support for more repos e.g. MLabs.
+  - design sketch:
+    https://github.com/haskell/security-advisories/issues/240
+
+## cabal depedendency confusion advisory
+
+- https://github.com/haskell/security-advisories/pull/281
+- There are mitigations since v3.4.0.0, propose to set that as
+  `fixed` version.
+- Not everyone agrees; discussion continues.


### PR DESCRIPTION
Also correct the "previously" link in the 2025-05-28 meeting notes.


---

## Advisory

- [ ] It's not duplicated
- [ ] All fields are filled
- [ ] It is validated by `hsec-tools`

## hsec-tools

- [ ] Previous advisories are still valid
