### PR TITLE
docs: document SRT packages and maintainership policies

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,11 @@
 # Haskell Security Response Team documentation
 
-The files in the directory document the functional and
+The files in this directory document the functional and
 administrative processes of the Haskell Security Response Team.
 
 - [SRT membership processes](./membership.md)
 - [Quarterly reports](./reports.md)
+- [SRT-owned Hackage packages and maintainership policies](./packages.md)
 
 Documentation for our tools, libraries and the advisory source
 format live in the `code/` directory of the main repo.

--- a/docs/membership.md
+++ b/docs/membership.md
@@ -31,10 +31,13 @@ These are:
 
 - Update the member list at https://www.haskell.org/security/.
   By pull request against
-  [https://github.com/haskell-infra/www.haskell.org/](haskell-infra/www.haskell.org).
+  [haskell-infra/www.haskell.org](https://github.com/haskell-infra/www.haskell.org/).
 
 - Announce the membership change(s) on [Discourse].  Usually this
   could be included in the quarterly report.
+
+- Add (or remove) the member as a maintainer of SRT-owned [Hackage
+  packages](./packages.md), if appropriate.
 
 [haskell-infra]: https://github.com/haskell-infra/haskell-admins
 [Discourse]: https://discourse.haskell.org/

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -1,0 +1,20 @@
+## Packages owned by the Haskell SRT
+
+- [cvss](https://hackage.haskell.org/package/cvss)
+- [hsec-core](https://hackage.haskell.org/package/hsec-core)
+- [hsec-sync](https://hackage.haskell.org/package/hsec-sync)
+- [hsec-tools](https://hackage.haskell.org/package/hsec-tools)
+- [osv](https://hackage.haskell.org/package/osv)
+- [purl](https://hackage.haskell.org/package/purl)
+
+## Maintainership policies
+
+At all times, at least 2 SRT members should be in the maintainer
+group for every SRT-owned package.
+
+Trusted collaborators can be added as maintainers at the discretion
+of the SRT.
+
+Non-SRT maintainers (including former SRT members) must be regularly
+reviewed.  We will revoke the maintainership of inactive or
+unresponsive non-SRT maintainers, for safekeeping.

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -18,7 +18,7 @@ The canonical version of each report is committed to this repo under
 Each report should also be republished on [Discourse], and added to
 the list of reports at https://www.haskell.org/security/ (file a
 pull request against
-[https://github.com/haskell-infra/www.haskell.org/](haskell-infra/www.haskell.org)).
+[haskell-infra/www.haskell.org](https://github.com/haskell-infra/www.haskell.org/)).
 
 Reports for the previous quarter should generally be published in
 the first few weeks following that quarter.  In some cases we have


### PR DESCRIPTION
---

## Advisory

- [ ] It's not duplicated
- [ ] All fields are filled
- [ ] It is validated by `hsec-tools`

## hsec-tools

- [ ] Previous advisories are still valid
