### PR TITLE
feat: add links in OSV exports (#165, #252)

### DIFF
--- a/code/hsec-tools/CHANGELOG.md
+++ b/code/hsec-tools/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Move `isVersionAffectedBy` and `isVersionRangeAffectedBy` to `Security.Advisories.Core` (`hsec-core`)
 * Add support for GHC component in `query is-affected`
+* Add `model.database_specific.{repository,osvs,home}` and `model.affected.database_specific.{osv,human_link}` in OSV exports
 
 ## 0.2.0.2
 

--- a/code/hsec-tools/src/Security/Advisories/Convert/OSV.hs
+++ b/code/hsec-tools/src/Security/Advisories/Convert/OSV.hs
@@ -1,10 +1,16 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
-module Security.Advisories.Convert.OSV
-  ( convert
-  )
-  where
+module Security.Advisories.Convert.OSV (
+    convert,
+    convertWithLinks,
+    DbLinks (..),
+    AffectedLinks (..),
+    haskellLinks,
+)
+where
 
+import Data.Aeson
 import qualified Data.Text as T
 import Data.Void
 import Distribution.Pretty (prettyShow)
@@ -14,35 +20,36 @@ import qualified Security.OSV as OSV
 
 convert :: Advisory -> OSV.Model Void Void Void Void
 convert adv =
-  ( OSV.newModel'
-    (T.pack . printHsecId $ advisoryId adv)
-    (advisoryModified adv)
-  )
-  { OSV.modelPublished = Just $ advisoryPublished adv
-  , OSV.modelAliases = advisoryAliases adv
-  , OSV.modelRelated = advisoryRelated adv
-  , OSV.modelSummary = Just $ advisorySummary adv
-  , OSV.modelDetails = Just $ advisoryDetails adv
-  , OSV.modelReferences = advisoryReferences adv
-  , OSV.modelAffected = fmap mkAffected (advisoryAffected adv)
-  }
+    ( OSV.newModel'
+        (T.pack . printHsecId $ advisoryId adv)
+        (advisoryModified adv)
+    )
+        { OSV.modelPublished = Just $ advisoryPublished adv
+        , OSV.modelAliases = advisoryAliases adv
+        , OSV.modelRelated = advisoryRelated adv
+        , OSV.modelSummary = Just $ advisorySummary adv
+        , OSV.modelDetails = Just $ advisoryDetails adv
+        , OSV.modelReferences = advisoryReferences adv
+        , OSV.modelAffected = fmap mkAffected (advisoryAffected adv)
+        }
 
 mkAffected :: Affected -> OSV.Affected Void Void Void
 mkAffected aff =
-  OSV.Affected
-    { OSV.affectedPackage = mkPackage (affectedComponentIdentifier aff)
-    , OSV.affectedRanges = pure $ mkRange (affectedVersions aff)
-    , OSV.affectedSeverity = [OSV.Severity (affectedCVSS aff)]
-    , OSV.affectedEcosystemSpecific = Nothing
-    , OSV.affectedDatabaseSpecific = Nothing
-    }
+    OSV.Affected
+        { OSV.affectedPackage = mkPackage (affectedComponentIdentifier aff)
+        , OSV.affectedRanges = pure $ mkRange (affectedVersions aff)
+        , OSV.affectedSeverity = [OSV.Severity (affectedCVSS aff)]
+        , OSV.affectedEcosystemSpecific = Nothing
+        , OSV.affectedDatabaseSpecific = Nothing
+        }
 
 mkPackage :: ComponentIdentifier -> OSV.Package
-mkPackage ecosystem = OSV.Package
-  { OSV.packageName = packageName
-  , OSV.packageEcosystem = ecosystemName
-  , OSV.packagePurl = Nothing
-  }
+mkPackage ecosystem =
+    OSV.Package
+        { OSV.packageName = packageName
+        , OSV.packageEcosystem = ecosystemName
+        , OSV.packagePurl = Nothing
+        }
   where
     (ecosystemName, packageName) = case ecosystem of
         Hackage n -> ("Hackage", n)
@@ -54,5 +61,64 @@ mkRange ranges =
   where
     mkEvs :: AffectedVersionRange -> [OSV.Event T.Text]
     mkEvs range =
-      OSV.EventIntroduced (T.pack $ prettyShow $ affectedVersionRangeIntroduced range)
-      : maybe [] (pure . OSV.EventFixed . T.pack . prettyShow) (affectedVersionRangeFixed range)
+        OSV.EventIntroduced (T.pack $ prettyShow $ affectedVersionRangeIntroduced range)
+            : maybe [] (pure . OSV.EventFixed . T.pack . prettyShow) (affectedVersionRangeFixed range)
+
+convertWithLinks :: DbLinks -> Advisory -> OSV.Model DbLinks AffectedLinks Void Void
+convertWithLinks links adv =
+    OSV.Model
+        { OSV.modelDatabaseSpecific = Just links
+        , OSV.modelAffected = mkAffectedWithLinks links (advisoryId adv) <$> advisoryAffected adv
+        , ..
+        }
+  where
+    OSV.Model{..} = convert adv
+
+data DbLinks = DbLinks
+    { dbLinksRepository :: T.Text
+    , dbLinksOSVs :: T.Text
+    , dbLinksHome :: T.Text
+    }
+
+instance ToJSON DbLinks where
+    toJSON DbLinks{..} =
+        object
+            [ "repository" .= dbLinksRepository
+            , "osvs" .= dbLinksOSVs
+            , "home" .= dbLinksHome
+            ]
+
+haskellLinks :: DbLinks
+haskellLinks =
+    DbLinks
+        { dbLinksRepository = "https://github.com/haskell/security-advisories"
+        , dbLinksOSVs = "https://raw.githubusercontent.com/haskell/security-advisories/refs/heads/generated/osv-export"
+        , dbLinksHome = "https://haskell.github.io/security-advisories"
+        }
+
+data AffectedLinks = AffectedLinks
+    { affectedLinksOSV :: T.Text
+    , affectedLinksHumanLink :: T.Text
+    }
+
+instance ToJSON AffectedLinks where
+    toJSON AffectedLinks{..} =
+        object
+            [ "osv" .= affectedLinksOSV
+            , "human_link" .= affectedLinksHumanLink
+            ]
+
+mkAffectedWithLinks :: DbLinks -> HsecId -> Affected -> OSV.Affected AffectedLinks Void Void
+mkAffectedWithLinks links hsecId aff =
+    OSV.Affected
+        { OSV.affectedDatabaseSpecific =
+            Just
+                AffectedLinks
+                    { affectedLinksOSV = stripSlash (dbLinksOSVs links) <> "/" <> T.pack (show $ hsecIdYear hsecId) <> "/" <> T.pack (printHsecId hsecId) <> ".json"
+                    , affectedLinksHumanLink = stripSlash (dbLinksHome links) <> "/advisory/" <> T.pack (printHsecId hsecId) <> ".html"
+                    }
+        , ..
+        }
+  where
+    OSV.Affected{..} = mkAffected aff
+    stripSlash = T.dropWhileEnd (== '/')


### PR DESCRIPTION
---

## hsec-tools

- [x] Previous advisories are still valid

* Add `model.database_specific.{repository,osvs,home}` and `model.affected.database_specific.{osv,human_link}` in OSV exports

/cc @andrewpollock @MangoIV @tchoutri 