### PR TITLE
advisory: HSEC-2026-0006 - Cabal deletes project source files during configure (#317)

### DIFF
--- a/advisories/published/2026/HSEC-2026-0006.md
+++ b/advisories/published/2026/HSEC-2026-0006.md
@@ -1,0 +1,37 @@
+```toml
+[advisory]
+id = "HSEC-2026-0006"
+cwe = [73]
+keywords = ["cabal", "file-deletion", "configure"]
+
+[[references]]
+type = "REPORT"
+url = "https://github.com/haskell/cabal/issues/11176"
+
+[[references]]
+type = "INTRODUCED"
+url = "https://github.com/haskell/cabal/commit/3a9830bbdabef2f1009a69957966b778c7c1a9ee"
+
+[[affected]]
+package = "Cabal"
+cvss = "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N"
+
+[[affected.versions]]
+introduced = "2.2"
+```
+
+# Cabal deletes project source files during configure
+
+The `checkDuplicateHeaders` function in `Distribution.Simple.Configure` removes
+header files from the source directory when a header with the same name exists in
+both the build directory and the source directory.
+
+This behavior was introduced in commit `3a9830b` to resolve header precedence
+issues, as C compilers prefer relative includes over `-I` search paths. The
+workaround uses `removeFile` on source directory files, which is destructive and
+should not happen during a build process.
+
+While the current implementation does not follow symlinks, the deletion of source
+files during a build operation is a security issue. This could potentially lead to
+arbitrary file deletion if combined with symlink-following behavior in future
+versions or specific system configurations.

--- a/advisories/published/2026/HSEC-2026-0006.md
+++ b/advisories/published/2026/HSEC-2026-0006.md
@@ -31,7 +31,6 @@ issues, as C compilers prefer relative includes over `-I` search paths. The
 workaround uses `removeFile` on source directory files, which is destructive and
 should not happen during a build process.
 
-While the current implementation does not follow symlinks, the deletion of source
-files during a build operation is a security issue. This could potentially lead to
-arbitrary file deletion if combined with symlink-following behavior in future
-versions or specific system configurations.
+While the current implementation does not follow symlinks explicitly, the
+deletion of source files outside of the project  during a build operation is
+possible on Microsoft Windows.


### PR DESCRIPTION
## Advisory

- [x] It's not duplicated
- [x] All fields are filled
- [x] It is validated by `hsec-tools`
