### PR TITLE
add CVE aliases for hackage-server advisories

### DIFF
--- a/advisories/published/2024/HSEC-2024-0004.md
+++ b/advisories/published/2024/HSEC-2024-0004.md
@@ -3,6 +3,7 @@
 id = "HSEC-2024-0004"
 cwe = [829]
 keywords = ["hackage", "xss", "supply-chain"]
+aliases = ["CVE-2026-40470"]
 
 [[affected]]
 package = "hackage-server"

--- a/advisories/published/2026/HSEC-2026-0002.md
+++ b/advisories/published/2026/HSEC-2026-0002.md
@@ -3,6 +3,7 @@
 id = "HSEC-2026-0002"
 cwe = [352]
 keywords = ["hackage", "csrf"]
+aliases = ["CVE-2026-40471"]
 
 [[affected]]
 package = "hackage-server"

--- a/advisories/published/2026/HSEC-2026-0004.md
+++ b/advisories/published/2026/HSEC-2026-0004.md
@@ -3,6 +3,7 @@
 id = "HSEC-2026-0004"
 cwe = [84]
 keywords = ["hackage", "xss", "supply-chain"]
+aliases = ["CVE-2026-40472"]
 
 [[affected]]
 package = "hackage-server"


### PR DESCRIPTION
We requested CVE assignments for a handful of critical
hackage-server vulnerabilities.  Courtesy of the Red Hat CNA-LR.
Add the aliases to the corresponding HSEC advisories.