### PR TITLE
Fix link in HSEC-2025-0002

### DIFF
--- a/advisories/published/2025/HSEC-2025-0002.md
+++ b/advisories/published/2025/HSEC-2025-0002.md
@@ -20,7 +20,7 @@ fixed = "1.0.3"
 
 [[references]]
 type = "ARTICLE"
-url = "https://portswigger.net/daily-swig/dozens-of-cryptography-libraries-vulnerable-to-private-key-theft"
+url = "https://web.archive.org/web/20250917120037/https://portswigger.net/daily-swig/dozens-of-cryptography-libraries-vulnerable-to-private-key-theft"
 [[references]]
 type = "ARTICLE"
 url = "https://github.com/MystenLabs/ed25519-unsafe-libs"


### PR DESCRIPTION
Link: https://portswigger.net/daily-swig/dozens-of-cryptography-libraries-vulnerable-to-private-key-theft
returns `HTTP 301 Moved Permanently`.

This replaces it with the version archived by `Wayback Machine`: 
https://web.archive.org/web/20250917120037/https://portswigger.net/daily-swig/dozens-of-cryptography-libraries-vulnerable-to-private-key-theft

## Advisory

- [x] It's not duplicated
- [ ] All fields are filled
- [ ] It is validated by `hsec-tools`

## hsec-tools

- [ ] Previous advisories are still valid
