### PR TITLE
Add Ord for GHCComponent

### DIFF
--- a/code/hsec-core/README.md
+++ b/code/hsec-core/README.md
@@ -11,5 +11,5 @@ We aim to support both regular cabal-based and nix-based builds.
 Run (and auto update) the golden test:
 
 ```ShellSession
-cabal test -O0 --test-show-details=direct --test-option=--accept
+cabal test -O0 --test-show-details=direct
 ```

--- a/code/hsec-core/src/Security/Advisories/Core/Advisory.hs
+++ b/code/hsec-core/src/Security/Advisories/Core/Advisory.hs
@@ -82,7 +82,7 @@ newtype RepositoryName
 
 -- Keep this list in sync with the 'ghcComponentFromText' below
 data GHCComponent = GHCCompiler | GHCi | GHCRTS | GHCPkg | RunGHC | IServ | HP2PS | HPC | HSC2HS | Haddock
-  deriving stock (Show, Eq, Enum, Bounded)
+  deriving stock (Show, Eq, Ord, Enum, Bounded)
 
 ghcComponentToText :: GHCComponent -> Text
 ghcComponentToText c = case c of


### PR DESCRIPTION
## Changes `hsec-core`
* add `Ord` for `GHCComponent` as proposed in cabal-audit: https://github.com/MangoIV/cabal-audit/pull/70#discussion_r3110403263
* update command to run tests in README

---

## Advisory

- [x] It's not duplicated
- [ ] All fields are filled
- [ ] It is validated by `hsec-tools`

## hsec-tools

- [ ] Previous advisories are still valid
