### PR TITLE
fix: remove spurious hsec-core arg from hsec-sync callCabal2nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,7 @@
             (pkgs.haskellPackages.callCabal2nix
               "hsec-sync"
               ./code/hsec-sync
-              { inherit hsec-core; });
+              { });
 
         gitconfig =
           pkgs.writeTextFile {


### PR DESCRIPTION
## Summary

- `hsec-sync` was called via `callCabal2nix` with `{ inherit hsec-core; }`, but `hsec-sync` has no dependency on `hsec-core` in its cabal file
- The generated `default.nix` therefore has no `hsec-core` parameter, causing `nix flake check` to error with: `function 'anonymous lambda' called with unexpected argument 'hsec-core'`
- Fix: pass `{ }` instead

## Test plan

- [x] `nix flake check` passes locally