### PR TITLE
advisory DoS on floating point exponent and year

### DIFF
--- a/advisories/published/2026/HSEC-2026-0007.md
+++ b/advisories/published/2026/HSEC-2026-0007.md
@@ -1,0 +1,78 @@
+```toml
+[advisory]
+id = "HSEC-2026-0007"
+cwe = [400]
+keywords = ["aeson", "text-iso8601", "dos", "memory-exhaustion", "json"]
+
+[[references]]
+type = "FIX"
+url = "https://github.com/haskell/aeson/commit/4e286806524702b562efbb36aa04ec976ec8fb90"
+
+[[references]]
+type = "FIX"
+url = "https://github.com/haskell/aeson/commit/42775f45ff8dad934d44617f6f38ee874e1c9df1"
+
+[[affected]]
+package = "aeson"
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+
+[[affected.versions]]
+introduced = "0.12.0.0"
+fixed = "2.3.0.0"
+
+[[affected]]
+package = "text-iso8601"
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+
+[[affected.versions]]
+introduced = "0.1"
+fixed = "0.2.0.0"
+```
+
+# Denial of Service and Memory Exhaustion in aeson and text-iso8601
+
+Two Denial of Service (DoS) and memory exhaustion vulnerabilities were identified in the `aeson` and `text-iso8601` packages. These vulnerabilities allow an attacker to exhaust server memory and crash the host process by supplying maliciously crafted JSON payloads.
+
+## 1. `withBoundedScientific_` DoS / Memory Exhaustion (`aeson`)
+
+A vulnerability exists in `aeson`'s `withBoundedScientific_` function (located in `src/Data/Aeson/Types/FromJSON.hs`). The exponent bounds check only rejects large positive exponents (`exp10 > 1024`) but fails to reject arbitrarily large negative exponents.
+
+When an attacker sends a JSON number with a massive negative exponent (e.g., `1e-999999999`), the value bypasses the check and flows into `realToFrac`, which computes `fromRational . toRational`. For such a large negative exponent, `toRational` produces a GMP Integer with approximately 1 billion decimal digits, causing immediate and severe memory exhaustion.
+
+Affected `FromJSON` instances:
+
+* `Fixed a` (including `Centi`, `Pico`, `Nano`, etc.)
+* `NominalDiffTime`
+* `DiffTime`
+
+## 2. `parseYear_` DoS / Memory Exhaustion (`text-iso8601`)
+
+A second vulnerability exists in the `text-iso8601` library's year parser (`parseYear_` in `src/Data/Time/FromText.hs`), which `aeson` relies upon for all of its date/time `FromJSON` instances.
+
+The year parser loops over digit characters with no upper bound constraint. The accumulated digits are then passed to `textToInteger`, which converts the arbitrarily long decimal string into a Haskell Integer (an arbitrary-precision bignum). Because this conversion is super-linear in the number of digits, an attacker can send a JSON date string with millions of digits in the year position (e.g., `{"date": "999...999-01-01T00:00:00Z"}`). A relatively small payload (~1MB) can cause seconds of CPU time and hundreds of megabytes of memory consumption, creating a practical asymmetric DoS vector.
+
+Affected `FromJSON` instances (via `aeson`):
+
+* `Day`
+* `UTCTime`
+* `LocalTime`
+* `ZonedTime`
+* `TimeOfDay`
+* `Month`
+* `Quarter`
+
+## Resolution
+
+These issues were resolved by introducing proper bounds checks:
+
+1. `aeson` now applies an absolute bounds check to both positive and negative exponents (`abs exp10 > 1024`).
+2. `text-iso8601` now enforces an upper bound limit on the number of year digits accepted by `parseYear_`.
+
+Users are strongly advised to update to the patched versions:
+
+* `aeson-2.3.0.0` or later
+* `text-iso8601-0.2.0.0` or later
+
+## Acknowledgements
+
+The vulnerabilities were reported Nathan Walsh, and patched by Li-yao Xia.


### PR DESCRIPTION
---

## Advisory

- [x] It's not duplicated
- [x] All fields are filled
- [x] It is validated by `hsec-tools`
