### PR TITLE
Fix HSEC-2024-0008 affected range for GHC 9.10

### DIFF
--- a/advisories/published/2024/HSEC-2024-0008.md
+++ b/advisories/published/2024/HSEC-2024-0008.md
@@ -18,6 +18,7 @@ fixed = "9.8.3"
 
 [[affected.versions]]
 introduced = "9.10.1"
+fixed = "9.10.2"
 
 [[references]]
 type = "REPORT"


### PR DESCRIPTION
GHC 9.10.2 [release notes](https://downloads.haskell.org/ghc/9.10.2/docs/users_guide/9.10.2-notes.html#native-code-generator-backend) list #23034 as fixed:

> PowerPC: Fix sign hints in C calls. This bug caused segfaults when using FFI under some circumstances. ([#23034](https://gitlab.haskell.org/ghc/ghc/issues/23034))

and [comment](https://gitlab.haskell.org/ghc/ghc/-/issues/23034#note_593249) by @TristanCacqueray

> Just to confirm because this is not mentioned in the release notes, but this is fixed in 9.6.6, 9.8.3 and in the upcoming 9.10.2 .

This PR changes the 9.10 range to:
```text
  >=9.10.1 && <9.10.2
```

Without this, tools report GHC 9.10.2 and later as affected.

## Advisory

- [x] It's not duplicated
- [x] All fields are filled
- [ ] It is validated by `hsec-tools`

## hsec-tools

- [x] Previous advisories are still valid
