### PR TITLE
Update Haskell dependency bounds

### DIFF
--- a/code/cvss/cvss.cabal
+++ b/code/cvss/cvss.cabal
@@ -35,7 +35,7 @@ library
 
   build-depends:
     , base        >=4.14 && <5
-    , containers  >=0.6  && <0.8
+    , containers  >=0.6  && <0.9
     , text        >=1.2  && <3
 
   hs-source-dirs:   src

--- a/code/hsec-core/hsec-core.cabal
+++ b/code/hsec-core/hsec-core.cabal
@@ -41,15 +41,15 @@ library
 
   build-depends:
     , base          >=4.14    && <5
-    , Cabal-syntax  >=3.8.1.0 && <3.15
-    , containers    >=0.6     && <0.8
+    , Cabal-syntax  >=3.8.1.0 && <3.17
+    , containers    >=0.6     && <0.9
     , cvss          >=0.2     && <0.4
     , network-uri   >=2.6.3.0 && <2.8
     , osv           >=0.1     && <0.3
     , pandoc-types  >=1.22    && <2
     , safe          >=0.3     && <0.4
     , text          >=1.2     && <3
-    , time          >=1.9     && <1.15
+    , time          >=1.9     && <1.17
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/code/hsec-sync/hsec-sync.cabal
+++ b/code/hsec-sync/hsec-sync.cabal
@@ -38,7 +38,7 @@ library
     , filepath      >=1.4   && <1.6
     , http-client   >=0.7.0 && <0.8
     , lens          >=5.1   && <5.4
-    , tar           >=0.5   && <0.7
+    , tar           >=0.5   && <0.8
     , temporary     >=1     && <2
     , text          >=1.2   && <3
     , transformers  >=0.5   && <0.7
@@ -62,7 +62,7 @@ executable hsec-sync
   build-depends:
     , base                  >=4.14    && <5
     , hsec-sync
-    , optparse-applicative  >=0.17    && <0.19
+    , optparse-applicative  >=0.17    && <0.20
 
   hs-source-dirs:   app
   default-language: Haskell2010

--- a/code/hsec-tools/hsec-tools.cabal
+++ b/code/hsec-tools/hsec-tools.cabal
@@ -61,25 +61,25 @@ library
     , atom-conduit          >=0.9      && <0.10
     , base                  >=4.14     && <5
     , bytestring            >=0.10     && <0.14
-    , Cabal-syntax          >=3.8.1.0  && <3.15
-    , commonmark            ^>=0.2.2
-    , commonmark-pandoc     >=0.2      && <0.3
+    , Cabal-syntax          >=3.8.1.0  && <3.17
+    , commonmark            >=0.2.2    && <0.4
+    , commonmark-pandoc     >=0.2      && <0.4
     , conduit               >=1.3      && <1.4
     , conduit-extra         >=1.3      && <1.4
-    , containers            >=0.6      && <0.8
+    , containers            >=0.6      && <0.9
     , cvss                  >=0.2      && <0.4
-    , data-default          >=0.7      && <0.8
+    , data-default          >=0.7      && <0.9
     , directory             <2
     , extra                 >=1.7      && <1.9
     , file-embed            >=0.0.13.0 && <0.0.17
     , filepath              >=1.4      && <1.6
-    , hsec-core             >=0.4.0.0  && <0.5
+    , hsec-core             >=0.4.0.0  && <0.6
     , lens                  >=5.1.0    && <5.4
     , lucid                 >=2.9.0    && <3
     , mtl                   >=2.2      && <2.4
     , network-uri           >=2.6.3.0  && <2.8
     , osv                   >=0.1      && <0.3
-    , pandoc                >=2.0      && <3.8
+    , pandoc                >=2.0      && <3.11
     , pandoc-types          >=1.22     && <2
     , parsec                >=3        && <4
     , pretty                >=1.0      && <1.2
@@ -87,9 +87,9 @@ library
     , process               >=1.6      && <1.7
     , refined               >=0.7      && <0.9
     , resourcet             >=1.2      && <1.4
-    , template-haskell      >=2.16.0.0 && <2.24
+    , template-haskell      >=2.16.0.0 && <2.25
     , text                  >=1.2      && <3
-    , time                  >=1.9      && <1.15
+    , time                  >=1.9      && <1.17
     , toml-parser           >=2.0.0.0  && <2.1
     , uri-bytestring        >=0.3      && <0.5
     , validation-selective  >=0.1      && <1
@@ -117,13 +117,13 @@ executable hsec-tools
     , aeson                 >=2.0.1.0 && <3
     , base                  >=4.14    && <5
     , bytestring            >=0.10    && <0.13
-    , Cabal-syntax          >=3.8.1.0 && <3.15
+    , Cabal-syntax          >=3.8.1.0 && <3.17
     , directory             <2
     , filepath              >=1.4     && <1.6
-    , hsec-core             >=0.4.0.0 && <0.5
+    , hsec-core             >=0.4.0.0 && <0.6
     , hsec-tools
     , network-uri           >=2.6.3.0 && <2.8
-    , optparse-applicative  >=0.17    && <0.19
+    , optparse-applicative  >=0.17    && <0.20
     , text                  >=1.2     && <3
     , transformers          >=0.5     && <0.7
     , validation-selective  >=0.1     && <1

--- a/code/osv/osv.cabal
+++ b/code/osv/osv.cabal
@@ -36,7 +36,7 @@ library
     , cvss                  >=0.2      && <0.4
     , purl                  >=0.1      && <0.2
     , text                  >=1.2      && <3
-    , time                  >=1.9      && <1.15
+    , time                  >=1.9      && <1.17
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/code/purl/purl.cabal
+++ b/code/purl/purl.cabal
@@ -17,9 +17,9 @@ library
   exposed-modules:  Data.Purl
   build-depends:
     , base             >=4.14   && <5
-    , aeson            >=2.0    && <2.3
+    , aeson            >=2.0    && <2.4
     , case-insensitive             <1.3
-    , containers       >=0.6    && <0.8
+    , containers       >=0.6    && <0.9
     , http-types       >=0.10.0 && <0.13
     , parsec           ==3.1.*
     , text             >=1.2    && <3


### PR DESCRIPTION
This PR updates the bounds of the Haskell dependencies.

Additionally, I'd recommend switching to `lucid2` instead of `lucid`, which has a lower dependency footprint.