### PR TITLE
advisory(HSEC-2026-0007): fix also available in aeson-2.2.5.1 and text-iso8601-0.1.1.2

### DIFF
--- a/advisories/published/2026/HSEC-2026-0007.md
+++ b/advisories/published/2026/HSEC-2026-0007.md
@@ -12,13 +12,21 @@ url = "https://github.com/haskell/aeson/commit/4e286806524702b562efbb36aa04ec976
 type = "FIX"
 url = "https://github.com/haskell/aeson/commit/42775f45ff8dad934d44617f6f38ee874e1c9df1"
 
+[[references]]
+type = "FIX"
+url = "https://github.com/haskell/aeson/commit/b6fb54b11ebf3e499685c4eeb2714ead522252cc"
+
+[[references]]
+type = "FIX"
+url = "https://github.com/haskell/aeson/commit/eaf97662b7b20499f65e3efcfa7cc175154ff151"
+
 [[affected]]
 package = "aeson"
 cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 
 [[affected.versions]]
 introduced = "0.12.0.0"
-fixed = "2.3.0.0"
+fixed = "2.2.5.1"
 
 [[affected]]
 package = "text-iso8601"
@@ -26,7 +34,7 @@ cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 
 [[affected.versions]]
 introduced = "0.1"
-fixed = "0.2.0.0"
+fixed = "0.1.1.2"
 ```
 
 # Denial of Service and Memory Exhaustion in aeson and text-iso8601
@@ -68,10 +76,12 @@ These issues were resolved by introducing proper bounds checks:
 1. `aeson` now applies an absolute bounds check to both positive and negative exponents (`abs exp10 > 1024`).
 2. `text-iso8601` now enforces an upper bound limit on the number of year digits accepted by `parseYear_`.
 
+The fixes first shipped in `aeson-2.3.0.0` and `text-iso8601-0.2.0.0`, and have been backported to the previous release series as `aeson-2.2.5.1` and `text-iso8601-0.1.1.2`.
+
 Users are strongly advised to update to the patched versions:
 
-* `aeson-2.3.0.0` or later
-* `text-iso8601-0.2.0.0` or later
+* `aeson-2.2.5.1` or later
+* `text-iso8601-0.1.1.2` or later
 
 ## Acknowledgements
 


### PR DESCRIPTION
Amends HSEC-2026-0007 per
https://github.com/haskell/security-advisories/pull/326#issuecomment-5512017325.

The fixes were backported and released as `aeson-2.2.5.1` and
`text-iso8601-0.1.1.2` (2026-08-29, in lts-24.57). Record the earliest
patched versions in the affected ranges, reference the backport commits,
and update the Resolution section.

## Advisory

- [x] It's not duplicated
- [x] All fields are filled
- [x] It is validated by `hsec-tools`

## hsec-tools

- [x] Previous advisories are still valid